### PR TITLE
Sort dashboard tasks by actual due dates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -592,7 +592,11 @@ function UserDashboard({ onBack, onOpenCourse }) {
         if (t.assigneeId === userId) arr.push({ ...t, courseId: c.course.id, courseName: c.course.name });
       });
     });
-    return arr.sort((a, b) => (a.dueDate || '').localeCompare(b.dueDate || ''));
+    return arr.sort((a, b) => {
+      const da = a.dueDate ? new Date(a.dueDate).getTime() : Infinity;
+      const db = b.dueDate ? new Date(b.dueDate).getTime() : Infinity;
+      return da - db;
+    });
   }, [courses, userId]);
 
   return (


### PR DESCRIPTION
## Summary
- Sort user dashboard tasks by due date values instead of locale string comparison
- Ensure tasks without due dates appear after dated tasks

## Testing
- `node - <<'NODE'
const arr=[{id:1,dueDate:'2024-05-20'},{id:2,dueDate:''},{id:3,dueDate:'2024-05-19'},{id:4}];
arr.sort((a,b)=>{
  const da=a.dueDate?new Date(a.dueDate).getTime():Infinity;
  const db=b.dueDate?new Date(b.dueDate).getTime():Infinity;
  return da-db;
});
console.log(arr.map(t=>t.dueDate));
NODE`
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4edf5a17c832ba49d7c05092a3a15