### PR TITLE
feat: add course task duplication utility

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -808,6 +808,26 @@ function UserDashboard({ onBack, onOpenCourse, initialUserId }) {
     setSaveState('unsaved');
   };
 
+  const duplicateTask = (courseId, id) => {
+    setCourses((cs) => cs.map((c) => {
+      if (c.course.id !== courseId) return c;
+      const orig = c.tasks.find((t) => t.id === id);
+      if (!orig) return c;
+      const clone = {
+        ...orig,
+        id: uid(),
+        title: `${orig.title} (copy)`,
+        status: 'todo',
+        startDate: '',
+        dueDate: '',
+        completedDate: '',
+        depTaskId: null,
+      };
+      return { ...c, tasks: [...c.tasks, clone] };
+    }));
+    setSaveState('unsaved');
+  };
+
   const deleteTask = (courseId, id) => {
     setCourses((cs) => cs.map((c) => c.course.id === courseId ? { ...c, tasks: c.tasks.filter((t) => t.id !== id) } : c));
     setSaveState('unsaved');


### PR DESCRIPTION
## Summary
- add course task duplication with new clone fields
- keep duplicateTask ahead of deleteTask in App.jsx

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a67531527c832bb5d223d9d3b62673