### PR TITLE
Add Firestore rule for app collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -36,5 +36,9 @@ service cloud.firestore {
       allow read: if isSignedIn();
       allow create, update, delete: if isSignedIn() && hasRole(request.auth.uid,'pc');
     }
+
+    match /app/{docId} {
+      allow read, write: if true; // or use request.auth != null for signed-in users
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add rule for `/app/{docId}` allowing reads and writes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `firebase deploy --only firestore:rules` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b247cde9d8832ba2c166491de3f186