### PR TITLE
Add Firestore rule for app collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -36,5 +36,11 @@ service cloud.firestore {
       allow read: if isSignedIn();
       allow create, update, delete: if isSignedIn() && hasRole(request.auth.uid,'pc');
     }
+
+    match /app/{docId} {
+      allow read: if resource.data.password == "passthesalt";
+      allow create, update: if request.resource.data.password == "passthesalt";
+      allow delete: if resource.data.password == "passthesalt";
+    }
   }
 }


### PR DESCRIPTION
## Summary
- require static password `passthesalt` for `/app/{docId}` reads and writes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `firebase deploy --only firestore:rules` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b247cde9d8832ba2c166491de3f186