### PR TITLE
Allow access to password-protected course and task docs

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,14 +16,16 @@ service cloud.firestore {
       allow update: if isSignedIn() && (request.auth.uid == uid || hasRole(request.auth.uid, 'pc'));
     }
 
+    function hasCorrectPassword() {
+      return (request.resource != null && request.resource.data.password == "passthesalt") ||
+             (resource != null && resource.data.password == "passthesalt");
+    }
+
     match /courses/{courseId} {
-      allow read: if isSignedIn();
-      allow create, update: if isSignedIn() && hasRole(request.auth.uid,'pc');
+      allow read, write: if hasCorrectPassword();
 
       match /tasks/{taskId} {
-        allow read: if isSignedIn();
-        allow create: if isSignedIn() && hasRole(request.auth.uid,'pc');
-        allow update: if isSignedIn(); // MVP; can tighten later
+        allow read, write: if hasCorrectPassword();
       }
     }
 


### PR DESCRIPTION
## Summary
- permit course and task document reads/writes when either the incoming or existing data carries the secret password

## Testing
- `npm test` *(fails: Missing script: "test")*
- `firebase deploy --only firestore:rules` *(fails: command not found: firebase)*

------
https://chatgpt.com/codex/tasks/task_e_68b24dd74704832b8135183dc40b6e1e