### PR TITLE
Refactor MilestoneCard with memoized task sorting

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -635,6 +635,7 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
                 onUpdate={updateTask}
                 onDelete={deleteTask}
                 onDuplicate={duplicateTask}
+                onDuplicateMilestone={duplicateMilestone}
                 onAddLink={(id, url) => patchTaskLinks(id, 'add', url)}
                 onRemoveLink={(id, idx) => patchTaskLinks(id, 'remove', idx)}
               />

--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { Copy as CopyIcon } from 'lucide-react';
 import TaskCard from './TaskCard.jsx';
 
 export default function MilestoneCard({
@@ -10,20 +11,49 @@ export default function MilestoneCard({
   onUpdate,
   onDelete,
   onDuplicate,
+  onDuplicateMilestone,
   onAddLink,
   onRemoveLink,
 }) {
+  const order = { todo: 0, inprogress: 1, done: 2 };
+
+  const { done, pct, tasksSorted } = useMemo(() => {
+    const done = tasks.filter((t) => t.status === 'done').length;
+    const pct = tasks.length ? Math.round((done / tasks.length) * 100) : 0;
+    const tasksSorted = [...tasks].sort(
+      (a, b) => order[a.status] - order[b.status] || a.order - b.order,
+    );
+    return { done, pct, tasksSorted };
+  }, [tasks]);
+
   return (
-    <details className="rounded-xl border border-black/10 bg-white p-4 flex flex-col md:flex-row">
-      <summary className="cursor-pointer font-semibold">
-        {milestone.title}
+    <details className="rounded-xl border border-black/10 bg-white flex flex-col md:flex-row">
+      <summary className="cursor-pointer select-none p-4 flex-1 flex items-start justify-between gap-2">
+        <div className="flex-1">
+          <div className="font-semibold">{milestone.title}</div>
+          <div className="h-2 bg-black/10 rounded-full mt-2 overflow-hidden">
+            <div className="h-full bg-black/40" style={{ width: `${pct}%` }} />
+          </div>
+        </div>
+        {onDuplicateMilestone && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onDuplicateMilestone(milestone.id);
+            }}
+            className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
+            title="Duplicate Milestone"
+          >
+            <CopyIcon size={16} />
+          </button>
+        )}
       </summary>
-      <div className="mt-2 flex flex-col gap-2 flex-1">
+      <div className="p-4 flex flex-col gap-2 flex-1">
         {milestone.goal && (
           <p className="text-sm text-black/60 mb-2">{milestone.goal}</p>
         )}
-        <div className="flex flex-col gap-2">
-          {tasks.map((t) => (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+          {tasksSorted.map((t) => (
             <TaskCard
               key={t.id}
               task={t}


### PR DESCRIPTION
## Summary
- memoize task sorting and completion stats for milestones
- display progress bar in milestone summaries
- render tasks in a responsive grid
- add milestone duplicate action and keep milestone details collapsed by default

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4eac499e4832bb692b4fcf5aa71e3