### PR TITLE
feat: collapse milestones section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -324,6 +324,7 @@ function CoursePMApp({ boot, isTemplateLabel = false, onBack, onStateChange, peo
   const [view, setView] = useState("board");
   const [milestoneFilter, setMilestoneFilter] = useState("all");
   const [listTab, setListTab] = useState("active");
+  const [milestonesCollapsed, setMilestonesCollapsed] = useState(false);
   const [saveState, setSaveState] = useState('saved');
   const firstRun = useRef(true);
 
@@ -613,6 +614,13 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
           <div className="flex items-center justify-between mb-2 px-1">
             <h2 className="font-semibold flex items-center gap-2"><Calendar size={18}/> Milestones</h2>
             <div className="flex items-center gap-2">
+              <button
+                onClick={() => setMilestonesCollapsed((v) => !v)}
+                title={milestonesCollapsed ? "Expand" : "Collapse"}
+                className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
+              >
+                {milestonesCollapsed ? <Plus size={16} /> : <Minus size={16} />}
+              </button>
               <div className="inline-flex items-center gap-2 rounded-2xl border border-black/10 bg-white px-3 py-2 shadow-sm">
                 <Filter size={16} className="text-black/50"/>
                 <select value={milestoneFilter} onChange={(e) => setMilestoneFilter(e.target.value)} className="text-sm outline-none bg-transparent">
@@ -623,24 +631,26 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
               <button onClick={() => addMilestone()} className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"><Plus size={16}/> Add Milestone</button>
             </div>
           </div>
-          <div className="space-y-2">
-            {filteredMilestones.map((m) => (
-              <MilestoneCard
-                key={m.id}
-                milestone={m}
-                tasks={groupedTasks[m.id] || []}
-                tasksAll={tasksRaw}
-                team={team}
-                milestones={milestones}
-                onUpdate={updateTask}
-                onDelete={deleteTask}
-                onDuplicate={duplicateTask}
-                onDuplicateMilestone={duplicateMilestone}
-                onAddLink={(id, url) => patchTaskLinks(id, 'add', url)}
-                onRemoveLink={(id, idx) => patchTaskLinks(id, 'remove', idx)}
-              />
-            ))}
-          </div>
+          {!milestonesCollapsed && (
+            <div className="space-y-2">
+              {filteredMilestones.map((m) => (
+                <MilestoneCard
+                  key={m.id}
+                  milestone={m}
+                  tasks={groupedTasks[m.id] || []}
+                  tasksAll={tasksRaw}
+                  team={team}
+                  milestones={milestones}
+                  onUpdate={updateTask}
+                  onDelete={deleteTask}
+                  onDuplicate={duplicateTask}
+                  onDuplicateMilestone={duplicateMilestone}
+                  onAddLink={(id, url) => patchTaskLinks(id, 'add', url)}
+                  onRemoveLink={(id, idx) => patchTaskLinks(id, 'remove', idx)}
+                />
+              ))}
+            </div>
+          )}
         </section>
 
         {/* Tasks */}


### PR DESCRIPTION
## Summary
- add milestonesCollapsed state and toggle to show or hide milestone list
- conditionally render milestone cards when section expanded

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b510c9ff50832b8961aaeabd951156