### PR TITLE
Refactor milestones toolbar and drag-and-drop handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -454,9 +454,67 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
   const updateMilestone  = (id, patch) => setState((s)=>({ ...s, milestones: s.milestones.map((m)=>(m.id===id?{...m,...patch}:m)) }));
   const addMilestone     = () => setState((s)=>({ ...s, milestones: [...s.milestones, { id: uid(), title: "New Milestone", start: todayStr(), goal: "" }] }));
   const deleteMilestone  = (id) => setState((s)=>({ ...s, milestones: s.milestones.filter((m)=>m.id!==id), tasks: s.tasks.map((t)=>(t.milestoneId===id?{...t, milestoneId: s.milestones[0]?.id}:t)) }));
-  const duplicateMilestone = (id) => setState((s)=>{ const src = s.milestones.find((m)=>m.id===id); if(!src) return s; const newMs = { id: uid(), title: `${src.title} (copy)`, start: src.start, goal: src.goal }; const related = s.tasks.filter((t)=>t.milestoneId===id); const nextOrder = s.tasks.length; const ld = s.course.courseLDIds[0] || (s.team.find((m)=>m.roleType==='LD')?.id ?? null); const clonedTasks = related.map((t,i)=>({ ...t, id: uid(), order: nextOrder+i, milestoneId: newMs.id, status: "todo", startDate: "", dueDate: "", completedDate: "", assigneeId: ld, depTaskId: null })); return { ...s, milestones: [...s.milestones, newMs], tasks: [...s.tasks, ...clonedTasks] }; });
+  const duplicateMilestone = (id) =>
+    setState((s) => {
+      const idx = s.milestones.findIndex((m) => m.id === id);
+      if (idx === -1) return s;
+      const src = s.milestones[idx];
+      const newMs = {
+        id: uid(),
+        title: `${src.title} (copy)`,
+        start: src.start,
+        goal: src.goal,
+      };
+      const related = s.tasks.filter((t) => t.milestoneId === id);
+      const nextOrder = s.tasks.length;
+      const ld =
+        s.course.courseLDIds[0] || (s.team.find((m) => m.roleType === "LD")?.id ?? null);
+      const clonedTasks = related.map((t, i) => ({
+        ...t,
+        id: uid(),
+        order: nextOrder + i,
+        milestoneId: newMs.id,
+        status: "todo",
+        startDate: "",
+        dueDate: "",
+        completedDate: "",
+        assigneeId: ld,
+        depTaskId: null,
+      }));
+      const ms = [...s.milestones];
+      ms.splice(idx + 1, 0, newMs);
+      return { ...s, milestones: ms, tasks: [...s.tasks, ...clonedTasks] };
+    });
 
   // Milestone DnD
+
+  const dragMilestoneId = useRef(null);
+  const onMilestoneDragStart = (id) => (e) => {
+    dragMilestoneId.current = id;
+    e.dataTransfer.effectAllowed = "move";
+    const el = e.currentTarget;
+    e.dataTransfer.setDragImage(el, el.offsetWidth / 2, el.offsetHeight / 2);
+  };
+  const onMilestoneDragOver = (e) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+  };
+  const onMilestoneDrop = (targetId) => (e) => {
+    e.preventDefault();
+    const srcId = dragMilestoneId.current;
+    dragMilestoneId.current = null;
+    if (!srcId || srcId === targetId) return;
+    setState((s) => {
+      const ms = [...s.milestones];
+      const from = ms.findIndex((m) => m.id === srcId);
+      if (from === -1) return s;
+      const [moved] = ms.splice(from, 1);
+      let to = targetId ? ms.findIndex((m) => m.id === targetId) : ms.length;
+      if (to === -1) to = ms.length;
+      ms.splice(to, 0, moved);
+      return { ...s, milestones: ms };
+    });
+  };
 
   // Members
   const updateMember = (id, patch) => setState((s)=>({ ...s, team: s.team.map((m)=>{ if(m.id!==id) return m; const next={...m,...patch}; if(patch.roleType) next.color = roleColor(patch.roleType); return next; }) }));
@@ -611,18 +669,11 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
 
         {/* Milestones */}
         <section>
-          <div className="flex items-center justify-between mb-2 px-1">
-            <h2 className="font-semibold flex items-center gap-2"><Calendar size={18}/> Milestones</h2>
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => setMilestonesCollapsed((v) => !v)}
-                title={milestonesCollapsed ? "Expand Milestones" : "Collapse Milestones"}
-                className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
-              >
-                {milestonesCollapsed ? <Plus size={16} /> : <Minus size={16} />}
-              </button>
-              {!milestonesCollapsed && (
-                <>
+          <div className="mb-2 px-1">
+            <div className="flex items-center justify-between">
+              <h2 className="font-semibold flex items-center gap-2"><Calendar size={18}/> Milestones</h2>
+              <div className="flex items-center gap-2">
+                {!milestonesCollapsed && (
                   <div className="inline-flex items-center gap-2 rounded-2xl border border-black/10 bg-white px-3 py-2 shadow-sm">
                     <Filter size={16} className="text-black/50"/>
                     <select value={milestoneFilter} onChange={(e) => setMilestoneFilter(e.target.value)} className="text-sm outline-none bg-transparent">
@@ -630,21 +681,26 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
                       {milestones.map((m) => (<option key={m.id} value={m.id}>{m.title}</option>))}
                     </select>
                   </div>
+                )}
+                {!milestonesCollapsed && (
                   <button onClick={() => addMilestone()} className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"><Plus size={16}/> Add Milestone</button>
-                </>
-              )}
+                )}
+                <button
+                  onClick={() => setMilestonesCollapsed((v) => !v)}
+                  title={milestonesCollapsed ? "Expand Milestones" : "Collapse Milestones"}
+                  className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-blue-500 bg-white text-blue-600 hover:bg-blue-50"
+                >
+                  {milestonesCollapsed ? <Plus size={16}/> : <Minus size={16}/>}
+                </button>
+              </div>
             </div>
+            <p className="text-xs text-slate-500 mt-1">Click a milestone title to expand or collapse.</p>
           </div>
           {!milestonesCollapsed && (
-            <div className="space-y-2">
-              <AnimatePresence>
-                {filteredMilestones.map((m) => (
-                  <motion.div
-                    key={m.id}
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: "auto" }}
-                    exit={{ opacity: 0, height: 0 }}
-                  >
+            <div className="space-y-2" onDragOver={onMilestoneDragOver} onDrop={onMilestoneDrop(null)}>
+              <AnimatePresence initial={false}>
+                {filteredMilestones.map(m => (
+                  <motion.div key={m.id} layout initial={{opacity:0,y:-20}} animate={{opacity:1,y:0}} exit={{opacity:0,y:-20}} transition={{duration:0.2}} draggable onDragStart={onMilestoneDragStart(m.id)} onDragOver={onMilestoneDragOver} onDrop={onMilestoneDrop(m.id)}>
                     <MilestoneCard
                       milestone={m}
                       tasks={groupedTasks[m.id] || []}
@@ -655,6 +711,7 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
                       onDelete={deleteTask}
                       onDuplicate={duplicateTask}
                       onDuplicateMilestone={duplicateMilestone}
+                      onDeleteMilestone={deleteMilestone}
                       onAddLink={(id, url) => patchTaskLinks(id, 'add', url)}
                       onRemoveLink={(id, idx) => patchTaskLinks(id, 'remove', idx)}
                     />
@@ -826,6 +883,17 @@ export function TaskCard({ task: t, team = [], milestones = [], tasks = [], onUp
       </div>
       {collapsed ? (
         <>
+          <div className="mt-1">
+            <select
+              value={t.status}
+              onChange={(e) => onUpdate?.(t.id, { status: e.target.value })}
+              className={`px-2 py-1 rounded-full border font-semibold text-xs ${statusPillClass(t.status)}`}
+            >
+              <option value="todo">To Do</option>
+              <option value="inprogress">In Progress</option>
+              <option value="done">Done</option>
+            </select>
+          </div>
           <div className="text-xs text-black/60 mt-1 truncate">
               <InlineText value={t.details} onChange={(v) => onUpdate?.(t.id, { details: v })} placeholder="Details…" />
             </div>
@@ -993,6 +1061,7 @@ function BoardView({ tasks, team, milestones, onUpdate, onDelete, onDragStart, o
                   </div>
                   {collapsed ? (
                     <>
+                      <div className="mt-1"><select value={t.status} onChange={(e)=>onUpdate(t.id,{ status:e.target.value })} className={`px-2 py-1 rounded-full border font-semibold text-xs ${statusPillClass(t.status)}`}><option value="todo">To Do</option><option value="inprogress">In Progress</option><option value="done">Done</option></select></div>
                       <div className="text-xs text-black/60 mt-1 truncate"><InlineText value={t.details} onChange={(v)=>onUpdate(t.id,{ details:v })} placeholder="Details…" /></div>
                       {t.note && <div className="text-[11px] text-slate-600 mt-1 truncate">📝 {t.note}</div>}
                       <div className="mt-2 flex items-center justify-between text-xs"><div className="flex items-center gap-2 min-w-0">{a ? <Avatar name={a.name} roleType={a.roleType} avatar={a.avatar} /> : <span className="text-black/40">—</span>}<span className="truncate">{a ? `${a.name} (${a.roleType})` : 'Unassigned'}</span></div><div className="flex items-center gap-2"><DuePill date={t.dueDate} status={t.status} />{t.status === "done" && <span className="text-slate-500">Completed: {t.completedDate || "—"}</span>}</div></div>

--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Copy as CopyIcon } from 'lucide-react';
+import { Copy as CopyIcon, Trash2 } from 'lucide-react';
 import TaskCard from './TaskCard.jsx';
 
 export default function MilestoneCard({
@@ -12,6 +12,7 @@ export default function MilestoneCard({
   onDelete,
   onDuplicate,
   onDuplicateMilestone,
+  onDeleteMilestone,
   onAddLink,
   onRemoveLink,
 }) {
@@ -36,18 +37,32 @@ export default function MilestoneCard({
             <div className="h-full bg-black/40" style={{ width: `${pct}%` }} />
           </div>
         </div>
-        {onDuplicateMilestone && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onDuplicateMilestone(milestone.id);
-            }}
-            className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
-            title="Duplicate Milestone"
-          >
-            <CopyIcon size={16} />
-          </button>
-        )}
+        <div className="flex items-center gap-1">
+          {onDuplicateMilestone && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDuplicateMilestone(milestone.id);
+              }}
+              className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
+              title="Duplicate Milestone"
+            >
+              <CopyIcon size={16} />
+            </button>
+          )}
+          {onDeleteMilestone && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDeleteMilestone(milestone.id);
+              }}
+              className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
+              title="Remove Milestone"
+            >
+              <Trash2 size={16} />
+            </button>
+          )}
+        </div>
       </summary>
       <div className="p-4 flex flex-col gap-2">
         {milestone.goal && (


### PR DESCRIPTION
## Summary
- Clean up framer-motion import and implement milestone drag-and-drop helpers
- Simplify milestone toolbar and add collapse toggle
- Replace milestone list with animated, draggable layout
- Show status selector even when task cards are collapsed
- Allow removing milestones via new delete button
- Limit drag preview to milestone card and insert duplicated milestones after source
- Clarify milestone expand behavior and highlight collapse toggle

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b52fba1dc0832b80840544fa596c19