### PR TITLE
fix: consolidate milestones section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -634,50 +634,36 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
             ))}
           </div>
         </section>
-      {/* Milestones */}
-<section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
-  <div className="flex items-center justify-between mb-2 px-1">
-    <h2 className="font-semibold flex items-center gap-2"><Calendar size={18}/> Milestones</h2>
-    <div className="flex items-center gap-2">
-      {!milestonesCollapsed && (
-        <div className="inline-flex items-center gap-2 rounded-2xl border border-black/10 bg-white px-3 py-2 shadow-sm">
-          <Filter size={16} className="text-black/50"/>
-          <select
-            value={milestoneFilter}
-            onChange={e => setMilestoneFilter(e.target.value)}
-            className="text-sm outline-none bg-transparent"
-          >
-            <option value="all">All milestones</option>
-            {milestones.map(m => (
-              <option key={m.id} value={m.id}>
-                {m.title}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
-      {!milestonesCollapsed && (
-        <button
-          onClick={() => addMilestone()}
-          className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
-        >
-          <Plus size={16}/> Add Milestone
-        </button>
-      )}
-      <button
-        onClick={() => setMilestonesCollapsed(v => !v)}
-        title={milestonesCollapsed ? "Expand Milestones" : "Collapse Milestones"}
-        className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
-      >
-        {milestonesCollapsed ? <Plus size={16}/> : <Minus size={16}/>}
-      </button>
-    </div>
-    <p className="text-xs text-slate-500 mt-1">
-      Click a milestone title to expand or collapse.
-    </p>
-  </div>
-  {/* Milestone list follows here */}
-</section>
+        {/* Milestones */}
+        <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
+          <div className="mb-2 px-1">
+            <div className="flex items-center justify-between">
+              <h2 className="font-semibold flex items-center gap-2"><Calendar size={18}/> Milestones</h2>
+              <div className="flex items-center gap-2">
+                {!milestonesCollapsed && (
+                  <div className="inline-flex items-center gap-2 rounded-2xl border border-black/10 bg-white px-3 py-2 shadow-sm">
+                    <Filter size={16} className="text-black/50"/>
+                    <select value={milestoneFilter} onChange={e => setMilestoneFilter(e.target.value)} className="text-sm outline-none bg-transparent">
+                      <option value="all">All milestones</option>
+                      {milestones.map(m => <option key={m.id} value={m.id}>{m.title}</option>)}
+                    </select>
+                  </div>
+                )}
+                {!milestonesCollapsed && (
+                  <button onClick={() => addMilestone()} className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50">
+                    <Plus size={16}/> Add Milestone
+                  </button>
+                )}
+                <button
+                  onClick={() => setMilestonesCollapsed(v => !v)}
+                  title={milestonesCollapsed ? "Expand Milestones" : "Collapse Milestones"}
+                  className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
+                >
+                  {milestonesCollapsed ? <Plus size={16}/> : <Minus size={16}/>}
+                </button>
+              </div>
+            </div>
+            <p className="text-xs text-slate-500 mt-1">Click a milestone title to expand or collapse.</p>
           </div>
           {!milestonesCollapsed && (
             <div className="space-y-2" onDragOver={onMilestoneDragOver} onDrop={onMilestoneDrop(null)}>


### PR DESCRIPTION
## Summary
- Keep milestones filter, buttons, collapse toggle, and drag list within a single section
- Resolve header markup conflict in milestones block
- Move help text below header so collapse toggle sits at far right

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5843f9df4832bbe0bb5f309f5a57a