### PR TITLE
refactor: replace milestones block

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -666,31 +666,46 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
         {/* Milestones */}
         <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
           <div className="flex items-center justify-between mb-2 px-1">
-            <h2 className="font-semibold flex items-center gap-2"><Calendar size={18}/> Milestones</h2>
+            <h2 className="font-semibold flex items-center gap-2">
+              <Calendar size={18} /> Milestones
+            </h2>
             <div className="flex items-center gap-2">
               {!milestonesCollapsed && (
                 <div className="inline-flex items-center gap-2 rounded-2xl border border-black/10 bg-white px-3 py-2 shadow-sm">
-                  <Filter size={16} className="text-black/50"/>
-                  <select value={milestoneFilter} onChange={e => setMilestoneFilter(e.target.value)} className="text-sm outline-none bg-transparent">
+                  <Filter size={16} className="text-black/50" />
+                  <select
+                    value={milestoneFilter}
+                    onChange={e => setMilestoneFilter(e.target.value)}
+                    className="text-sm outline-none bg-transparent"
+                  >
                     <option value="all">All milestones</option>
-                    {milestones.map(m => <option key={m.id} value={m.id}>{m.title}</option>)}
+                    {milestones.map(m => (
+                      <option key={m.id} value={m.id}>
+                        {m.title}
+                      </option>
+                    ))}
                   </select>
                 </div>
               )}
               {!milestonesCollapsed && (
-                <button onClick={() => addMilestone()} className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50">
-                  <Plus size={16}/> Add Milestone
+                <button
+                  onClick={() => addMilestone()}
+                  className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
+                >
+                  <Plus size={16} /> Add Milestone
                 </button>
               )}
               <button
                 onClick={() => setMilestonesCollapsed(v => !v)}
-                title={milestonesCollapsed ? "Expand Milestones" : "Collapse Milestones"}
+                title={milestonesCollapsed ? 'Expand Milestones' : 'Collapse Milestones'}
                 className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
               >
-                {milestonesCollapsed ? <Plus size={16}/> : <Minus size={16}/>}
+                {milestonesCollapsed ? <Plus size={16} /> : <Minus size={16} />}
               </button>
             </div>
-            <p className="text-xs text-slate-500 mt-1">Click a milestone title to expand or collapse.</p>
+            <p className="text-xs text-slate-500 mt-1">
+              Click a milestone title to expand or collapse.
+            </p>
           </div>
           {!milestonesCollapsed && (
             <div className="space-y-2" onDragOver={onMilestoneDragOver} onDrop={onMilestoneDrop(null)}>
@@ -699,10 +714,10 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
                   <motion.div
                     key={m.id}
                     layout
-                    initial={{opacity:0, y:-20}}
-                    animate={{opacity:1, y:0}}
-                    exit={{opacity:0, y:-20}}
-                    transition={{duration:0.2}}
+                    initial={{ opacity: 0, y: -20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -20 }}
+                    transition={{ duration: 0.2 }}
                     draggable
                     onDragStart={onMilestoneDragStart(m.id)}
                     onDragOver={onMilestoneDragOver}


### PR DESCRIPTION
## Summary
- rewrite Milestones section with collapsible filtering controls and add button
- maintain milestone list rendering and cleanup

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b64e23af14832b95989a010a03a103