### PR TITLE
feat: improve milestones toggle accessibility

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -670,52 +670,50 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
         </section>
         {/* Milestones */}
         <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
-          <div className="mb-2 px-1">
-            <div className="flex items-center justify-between">
-              <h2 className="font-semibold flex items-center gap-2">
-                <Calendar size={18} /> Milestones
-              </h2>
-              <div className="flex items-center gap-2">
-                {!milestonesCollapsed && (
-                  <div className="inline-flex items-center gap-2 rounded-2xl border border-black/10 bg-white px-3 py-2 shadow-sm">
-                    <Filter size={16} className="text-black/50"/>
-                    <select
-                      value={milestoneFilter}
-                      onChange={e => setMilestoneFilter(e.target.value)}
-                      className="text-sm outline-none bg-transparent"
-                    >
-                      <option value="all">All milestones</option>
-                      {milestones.map(m => (
-                        <option key={m.id} value={m.id}>
-                          {m.title}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                )}
-                {!milestonesCollapsed && (
-                  <button
-                    onClick={() => addMilestone()}
-                    className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
+          <div className="flex items-center justify-between mb-2 px-1">
+            <h2 className="font-semibold flex items-center gap-2">
+              <Calendar size={18} /> Milestones
+            </h2>
+            <div className="flex items-center gap-2">
+              {!milestonesCollapsed && (
+                <div className="inline-flex items-center gap-2 rounded-2xl border border-black/10 bg-white px-3 py-2 shadow-sm">
+                  <Filter size={16} className="text-black/50"/>
+                  <select
+                    value={milestoneFilter}
+                    onChange={e => setMilestoneFilter(e.target.value)}
+                    className="text-sm outline-none bg-transparent"
                   >
-                    <Plus size={16}/> Add Milestone
-                  </button>
-                )}
+                    <option value="all">All milestones</option>
+                    {milestones.map(m => (
+                      <option key={m.id} value={m.id}>
+                        {m.title}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+              {!milestonesCollapsed && (
                 <button
-                  onClick={() => setMilestonesCollapsed(v => !v)}
-                  title={milestonesCollapsed ? 'Expand Milestones' : 'Collapse Milestones'}
-                  aria-label={milestonesCollapsed ? 'Expand milestones' : 'Collapse milestones'}
-                  aria-expanded={!milestonesCollapsed}
-                  className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
+                  onClick={() => addMilestone()}
+                  className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
                 >
-                  {milestonesCollapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
+                  <Plus size={16}/> Add Milestone
                 </button>
-              </div>
+              )}
+              <button
+                onClick={() => setMilestonesCollapsed(v => !v)}
+                title={milestonesCollapsed ? 'Expand Milestones' : 'Collapse Milestones'}
+                aria-label={milestonesCollapsed ? 'Expand milestones' : 'Collapse milestones'}
+                aria-expanded={!milestonesCollapsed}
+                className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
+              >
+                {milestonesCollapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
+              </button>
             </div>
-            <p className="text-xs text-slate-500 mt-1">
-              Click a milestone title to expand or collapse.
-            </p>
           </div>
+          <p className="text-xs text-slate-500 mt-1">
+            Click a milestone title to expand or collapse.
+          </p>
           {!milestonesCollapsed && (
             <div className="space-y-2" onDragOver={onMilestoneDragOver} onDrop={onMilestoneDrop(null)}>
               <AnimatePresence initial={false}>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,8 @@ import {
   Link2,
   GitBranch,
   Minus,
+  ChevronDown,
+  ChevronUp,
   ArrowLeft,
 } from "lucide-react";
 import { doc, getDoc, setDoc } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
@@ -463,6 +465,9 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
   const onMilestoneDragStart = (id) => (e) => {
     dragMilestoneId.current = id;
     e.dataTransfer.effectAllowed = "move";
+    const img = new Image();
+    img.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+    e.dataTransfer.setDragImage(img, 0, 0);
   };
   const onMilestoneDragOver = (e) => {
     e.preventDefault();
@@ -665,43 +670,47 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
         </section>
         {/* Milestones */}
         <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
-          <div className="flex items-center justify-between mb-2 px-1">
-            <h2 className="font-semibold flex items-center gap-2">
-              <Calendar size={18} /> Milestones
-            </h2>
-            <div className="flex items-center gap-2">
-              {!milestonesCollapsed && (
-                <div className="inline-flex items-center gap-2 rounded-2xl border border-black/10 bg-white px-3 py-2 shadow-sm">
-                  <Filter size={16} className="text-black/50" />
-                  <select
-                    value={milestoneFilter}
-                    onChange={e => setMilestoneFilter(e.target.value)}
-                    className="text-sm outline-none bg-transparent"
+          <div className="mb-2 px-1">
+            <div className="flex items-center justify-between">
+              <h2 className="font-semibold flex items-center gap-2">
+                <Calendar size={18} /> Milestones
+              </h2>
+              <div className="flex items-center gap-2">
+                {!milestonesCollapsed && (
+                  <div className="inline-flex items-center gap-2 rounded-2xl border border-black/10 bg-white px-3 py-2 shadow-sm">
+                    <Filter size={16} className="text-black/50"/>
+                    <select
+                      value={milestoneFilter}
+                      onChange={e => setMilestoneFilter(e.target.value)}
+                      className="text-sm outline-none bg-transparent"
+                    >
+                      <option value="all">All milestones</option>
+                      {milestones.map(m => (
+                        <option key={m.id} value={m.id}>
+                          {m.title}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+                {!milestonesCollapsed && (
+                  <button
+                    onClick={() => addMilestone()}
+                    className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
                   >
-                    <option value="all">All milestones</option>
-                    {milestones.map(m => (
-                      <option key={m.id} value={m.id}>
-                        {m.title}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              )}
-              {!milestonesCollapsed && (
+                    <Plus size={16}/> Add Milestone
+                  </button>
+                )}
                 <button
-                  onClick={() => addMilestone()}
-                  className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
+                  onClick={() => setMilestonesCollapsed(v => !v)}
+                  title={milestonesCollapsed ? 'Expand Milestones' : 'Collapse Milestones'}
+                  aria-label={milestonesCollapsed ? 'Expand milestones' : 'Collapse milestones'}
+                  aria-expanded={!milestonesCollapsed}
+                  className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
                 >
-                  <Plus size={16} /> Add Milestone
+                  {milestonesCollapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
                 </button>
-              )}
-              <button
-                onClick={() => setMilestonesCollapsed(v => !v)}
-                title={milestonesCollapsed ? 'Expand Milestones' : 'Collapse Milestones'}
-                className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
-              >
-                {milestonesCollapsed ? <Plus size={16} /> : <Minus size={16} />}
-              </button>
+              </div>
             </div>
             <p className="text-xs text-slate-500 mt-1">
               Click a milestone title to expand or collapse.


### PR DESCRIPTION
## Summary
- Use chevron icons instead of plus/minus for the milestones collapse toggle
- Add ARIA labels to announce expand/collapse state to screen readers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6b1f0c16c832b8c1acb1ffca99730