### PR TITLE
Improve mobile responsiveness and member navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,8 @@ import {
   Link2,
   GitBranch,
   Minus,
+  ChevronDown,
+  ChevronUp,
   ArrowLeft,
 } from "lucide-react";
 import { doc, getDoc, setDoc } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
@@ -43,6 +45,7 @@ const todayStr = () => new Date().toISOString().slice(0, 10);
 const fmt = (d) => new Date(d).toISOString().slice(0, 10);
 const clamp = (n, min, max) => Math.max(min, Math.min(max, n));
 const rolePalette = { LD: "#4f46e5", SME: "#16a34a", MM: "#0891b2", PM: "#ea580c", PA: "#a855f7", Other: "#64748b" };
+const roleOrder = Object.keys(rolePalette);
 const roleColor = (roleType) => rolePalette[roleType] || rolePalette.Other;
 
 const nextMemberName = (list) => {
@@ -463,6 +466,9 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
   const onMilestoneDragStart = (id) => (e) => {
     dragMilestoneId.current = id;
     e.dataTransfer.effectAllowed = "move";
+    const img = new Image();
+    img.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+    e.dataTransfer.setDragImage(img, 0, 0);
   };
   const onMilestoneDragOver = (e) => {
     e.preventDefault();
@@ -665,14 +671,14 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
         </section>
         {/* Milestones */}
         <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
-          <div className="flex items-center justify-between mb-2 px-1">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-2 px-1">
             <h2 className="font-semibold flex items-center gap-2">
               <Calendar size={18} /> Milestones
             </h2>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               {!milestonesCollapsed && (
                 <div className="inline-flex items-center gap-2 rounded-2xl border border-black/10 bg-white px-3 py-2 shadow-sm">
-                  <Filter size={16} className="text-black/50" />
+                  <Filter size={16} className="text-black/50"/>
                   <select
                     value={milestoneFilter}
                     onChange={e => setMilestoneFilter(e.target.value)}
@@ -692,21 +698,23 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
                   onClick={() => addMilestone()}
                   className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
                 >
-                  <Plus size={16} /> Add Milestone
+                  <Plus size={16}/> Add Milestone
                 </button>
               )}
               <button
                 onClick={() => setMilestonesCollapsed(v => !v)}
                 title={milestonesCollapsed ? 'Expand Milestones' : 'Collapse Milestones'}
+                aria-label={milestonesCollapsed ? 'Expand milestones' : 'Collapse milestones'}
+                aria-expanded={!milestonesCollapsed}
                 className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
               >
-                {milestonesCollapsed ? <Plus size={16} /> : <Minus size={16} />}
+                {milestonesCollapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
               </button>
             </div>
-            <p className="text-xs text-slate-500 mt-1">
-              Click a milestone title to expand or collapse.
-            </p>
           </div>
+          <p className="text-xs text-slate-500 mt-1">
+            Click a milestone title to expand or collapse.
+          </p>
           {!milestonesCollapsed && (
             <div className="space-y-2" onDragOver={onMilestoneDragOver} onDrop={onMilestoneDrop(null)}>
               <AnimatePresence initial={false}>
@@ -1116,7 +1124,7 @@ function BoardView({ tasks, team, milestones, onUpdate, onDelete, onDragStart, o
 // =====================================================
 // User Dashboard (NEW)
 // =====================================================
-function UserDashboard({ onOpenCourse, initialUserId }) {
+function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
   const [courses, setCourses] = useState(() => loadCourses());
   useEffect(() => {
     const onStorage = () => setCourses(loadCourses());
@@ -1295,6 +1303,14 @@ function UserDashboard({ onOpenCourse, initialUserId }) {
       <header className="sticky top-0 z-20 backdrop-blur supports-[backdrop-filter]:bg-white/60 bg-white/80 border-b border-black/5">
         <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between gap-3">
           <div className="flex items-center gap-3 min-w-0">
+            {onBack && (
+              <button
+                onClick={onBack}
+                className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm bg-slate-900 text-white border border-slate-900 shadow-sm hover:bg-slate-800"
+              >
+                <ArrowLeft size={16} /> Back to Courses
+              </button>
+            )}
             <div className="min-w-0">
               <div className="text-sm sm:text-base font-semibold truncate">User Dashboard</div>
               {user && <div className="text-xs text-black/60 truncate">{user.name}</div>}
@@ -1726,7 +1742,10 @@ function CoursesHub({
             <div className="text-sm text-black/60">No team members</div>
           ) : (
             <div className="flex flex-wrap gap-3">
-              {people.map((m) => (
+              {[...people].sort((a, b) => {
+                const roleCmp = roleOrder.indexOf(a.roleType) - roleOrder.indexOf(b.roleType);
+                return roleCmp !== 0 ? roleCmp : a.name.localeCompare(b.name);
+              }).map((m) => (
                 <div
                   key={m.id}
                   className="flex items-center gap-2 rounded-xl px-3 py-2 shadow border-2"
@@ -1755,7 +1774,13 @@ function CoursesHub({
                       </>
                     ) : (
                       <>
-                        <div className="font-medium leading-tight">{m.name}</div>
+                        <button
+                          type="button"
+                          onClick={() => onOpenUser(m.id)}
+                          className="font-medium leading-tight text-left hover:underline"
+                        >
+                          {m.name}
+                        </button>
                         <div className="text-xs text-black/60">{m.roleType}</div>
                       </>
                     )}
@@ -1907,7 +1932,13 @@ export default function PMApp() {
       />
     );
   } else if (view === "user") {
-    content = <UserDashboard onOpenCourse={openCourse} initialUserId={currentUserId} />;
+    content = (
+      <UserDashboard
+        onOpenCourse={openCourse}
+        initialUserId={currentUserId}
+        onBack={() => { setView("hub"); setPrevView("hub"); setCurrentUserId(null); }}
+      />
+    );
   } else if (currentCourseId === "__TEMPLATE__") {
     // open template editor
     const tpl = loadTemplate() || remapSeed(seed());

--- a/styles/app.css
+++ b/styles/app.css
@@ -34,11 +34,14 @@ button:focus, input:focus, select:focus, textarea:focus{outline:2px solid var(--
 .grid{display:grid;gap:12px}
 @media(min-width:720px){.grid.cards{grid-template-columns:repeat(3,1fr)}}
 @media(max-width:719px){.grid.cards{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:480px){.grid.cards{grid-template-columns:1fr}}
 .toolbar{display:flex;gap:8px;flex-wrap:wrap;margin:8px 0}
 .chip{background:var(--chip);border:1px solid var(--border);padding:6px 10px;border-radius:999px;font-size:12px;transition:background .12s ease,border-color .12s ease,transform .06s ease}
 .chip:active{transform:scale(.98)}
 .chip[aria-pressed="true"]{border-color:#60a5fa;background:#0b1220;color:#bfdbfe}
 .kboard{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}
+@media(max-width:720px){.kboard{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:480px){.kboard{grid-template-columns:1fr}}
 .kcol{background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:10px;min-height:120px;box-shadow:var(--elev-sm)}
 .kcol h4{margin:0 0 8px 0;font-size:12px;color:#cbd5e1}
 .kcol .count{font-size:12px;color:var(--muted)}
@@ -77,7 +80,8 @@ hr{border:0;border-top:1px solid var(--border);margin:12px 0}
 hr.soft{border:0;border-top:1px solid var(--border);opacity:.7}
 .footer{padding:16px 0;color:var(--muted);font-size:12px;text-align:center}
 .badge{display:inline-block;padding:3px 8px;border-radius:999px;background:#0b1220;border:1px solid #1a2640;font-size:11px;color:#93c5fd}
-.role-grid{display:grid;grid-template-columns:repeat(6,1fr);gap:8px}
+.role-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:8px}
+@media(max-width:480px){.role-grid{grid-template-columns:repeat(2,1fr)}}
 .role-grid label{display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--border);padding:8px 10px;border-radius:10px}
 .table{width:100%;border-collapse:separate;border-spacing:0 8px}
 .table th{font-size:12px;color:#94a3b8;text-align:left;padding:0 8px}


### PR DESCRIPTION
## Summary
- Allow milestone header controls to wrap on small screens
- Add extra-small breakpoints for card and role grids
- Reduce Kanban board columns on narrow viewports
- Sort team members by role and name and link names to user dashboards
- Add Back to Courses button on user dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6b1f0c16c832b8c1acb1ffca99730