### PR TITLE
Improve mobile responsiveness and member navigation

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -34,11 +34,14 @@ button:focus, input:focus, select:focus, textarea:focus{outline:2px solid var(--
 .grid{display:grid;gap:12px}
 @media(min-width:720px){.grid.cards{grid-template-columns:repeat(3,1fr)}}
 @media(max-width:719px){.grid.cards{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:480px){.grid.cards{grid-template-columns:1fr}}
 .toolbar{display:flex;gap:8px;flex-wrap:wrap;margin:8px 0}
 .chip{background:var(--chip);border:1px solid var(--border);padding:6px 10px;border-radius:999px;font-size:12px;transition:background .12s ease,border-color .12s ease,transform .06s ease}
 .chip:active{transform:scale(.98)}
 .chip[aria-pressed="true"]{border-color:#60a5fa;background:#0b1220;color:#bfdbfe}
 .kboard{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}
+@media(max-width:720px){.kboard{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:480px){.kboard{grid-template-columns:1fr}}
 .kcol{background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:10px;min-height:120px;box-shadow:var(--elev-sm)}
 .kcol h4{margin:0 0 8px 0;font-size:12px;color:#cbd5e1}
 .kcol .count{font-size:12px;color:var(--muted)}
@@ -77,7 +80,8 @@ hr{border:0;border-top:1px solid var(--border);margin:12px 0}
 hr.soft{border:0;border-top:1px solid var(--border);opacity:.7}
 .footer{padding:16px 0;color:var(--muted);font-size:12px;text-align:center}
 .badge{display:inline-block;padding:3px 8px;border-radius:999px;background:#0b1220;border:1px solid #1a2640;font-size:11px;color:#93c5fd}
-.role-grid{display:grid;grid-template-columns:repeat(6,1fr);gap:8px}
+.role-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:8px}
+@media(max-width:480px){.role-grid{grid-template-columns:repeat(2,1fr)}}
 .role-grid label{display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--border);padding:8px 10px;border-radius:10px}
 .table{width:100%;border-collapse:separate;border-spacing:0 8px}
 .table th{font-size:12px;color:#94a3b8;text-align:left;padding:0 8px}


### PR DESCRIPTION
## Summary
- Allow milestone header controls to wrap on small screens
- Add extra-small breakpoints for card and role grids
- Reduce Kanban board columns on narrow viewports
- Sort team members by role and name and link names to user dashboards
- Add Back to Courses button on user dashboard
- Highlight milestone drop position when rearranging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6b1f0c16c832b8c1acb1ffca99730