### PR TITLE
Use explicit Fragment and make milestones bar tappable

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, useRef } from "react";
+import React, { useEffect, useMemo, useState, useRef, Fragment } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   Plus,
@@ -623,7 +623,7 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
                 </div>
                 <div className="flex items-center gap-2">
                   {membersEditing ? (
-                    <>
+                    <Fragment>
                       <select
                         value={m.roleType}
                         onChange={(e) => updateMember(m.id, { roleType: e.target.value })}
@@ -664,7 +664,7 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
                       >
                         <Trash2 size={16} />
                       </button>
-                    </>
+                    </Fragment>
                   ) : (
                     <span className="text-sm">{m.roleType}</span>
                   )}
@@ -674,12 +674,18 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
           </div>
         </section>
         {/* Milestones */}
-        <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-2 px-1">
-            <h2 className="font-semibold flex items-center gap-2">
-              <Calendar size={18} /> Milestones
-            </h2>
-            <div className="flex flex-wrap items-center gap-2">
+          <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
+            <div
+              className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-2 px-1 cursor-pointer"
+              onClick={() => setMilestonesCollapsed(v => !v)}
+            >
+              <h2 className="font-semibold flex items-center gap-2">
+                <Calendar size={18} /> Milestones
+              </h2>
+              <div
+                className="flex flex-wrap items-center gap-2"
+                onClick={e => e.stopPropagation()}
+              >
               {!milestonesCollapsed && (
                 <div className="inline-flex items-center gap-2 rounded-2xl border border-black/10 bg-white px-3 py-2 shadow-sm">
                   <Filter size={16} className="text-black/50"/>
@@ -705,19 +711,19 @@ const tasksDone   = useMemo(() => { const arr = filteredTasks.filter((t) => t.st
                   <Plus size={16}/> Add Milestone
                 </button>
               )}
-              <button
-                onClick={() => setMilestonesCollapsed(v => !v)}
-                title={milestonesCollapsed ? 'Expand Milestones' : 'Collapse Milestones'}
-                aria-label={milestonesCollapsed ? 'Expand milestones' : 'Collapse milestones'}
-                aria-expanded={!milestonesCollapsed}
-                className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
-              >
-                {milestonesCollapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
-              </button>
+                <button
+                  onClick={() => setMilestonesCollapsed(v => !v)}
+                  title={milestonesCollapsed ? 'Expand Milestones' : 'Collapse Milestones'}
+                  aria-label={milestonesCollapsed ? 'Expand milestones' : 'Collapse milestones'}
+                  aria-expanded={!milestonesCollapsed}
+                  className="inline-flex items-center justify-center w-7 h-7 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
+                >
+                  {milestonesCollapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
+                </button>
             </div>
           </div>
           <p className="text-xs text-slate-500 mt-1">
-            Click a milestone title to expand or collapse.
+            Tap the Milestones bar to expand or collapse.
           </p>
           {!milestonesCollapsed && (
             <div


### PR DESCRIPTION
## Summary
- replace shorthand fragment with `<Fragment>` in member editor
- make milestones bar tappable to expand or collapse with updated guidance text

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b825e96c08832b85e8eaddc9ce12df