### PR TITLE
Clean index CSS and remove dark mode leftovers

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,8 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
-html, body, #root { height: 100%; }
-body { @apply bg-slate-50 text-slate-900 dark:bg-slate-900 dark:text-slate-100; }
+html, body, #root {
+  height: 100%;
+}
+body {
+  @apply bg-slate-50 text-slate-900;
+}
 
 @media (max-width: 640px) {
   html { font-size: 18px; }


### PR DESCRIPTION
## Summary
- strip dark-mode Tailwind utilities from index stylesheet
- format index.css and remove merge conflict markers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8bda02bac832b801eeb9d2ba94edb