### PR TITLE
Enable editing of milestone titles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -789,6 +789,7 @@ const tasksDone = useMemo(() => {
                       onDuplicate={duplicateTask}
                       onDuplicateMilestone={duplicateMilestone}
                       onDeleteMilestone={deleteMilestone}
+                      onUpdateMilestone={updateMilestone}
                       onAddLink={(id, url) => patchTaskLinks(id, 'add', url)}
                       onRemoveLink={(id, idx) => patchTaskLinks(id, 'remove', idx)}
                     />

--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { Copy as CopyIcon, Trash2, ChevronDown } from 'lucide-react';
 import TaskCard from './TaskCard.jsx';
 
@@ -15,7 +15,18 @@ export default function MilestoneCard({
   onDeleteMilestone,
   onAddLink,
   onRemoveLink,
+  onUpdateMilestone,
 }) {
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(milestone.title);
+  useEffect(() => setTitleDraft(milestone.title), [milestone.title]);
+  const commitTitle = () => {
+    setEditingTitle(false);
+    if (titleDraft !== milestone.title) {
+      onUpdateMilestone?.(milestone.id, { title: titleDraft });
+    }
+  };
+
   const statusOrder = { todo: 0, inprogress: 1, done: 2 };
 
   const { done, pct, tasksSorted } = useMemo(() => {
@@ -34,7 +45,37 @@ export default function MilestoneCard({
         <div className="flex items-center gap-2 flex-1">
           <ChevronDown className="w-4 h-4 transition-transform group-open:rotate-180" />
           <div className="flex-1">
-            <div className="font-semibold">{milestone.title}</div>
+            {onUpdateMilestone ? (
+              editingTitle ? (
+                <input
+                  autoFocus
+                  className="w-full font-semibold rounded border border-black/10 px-1"
+                  value={titleDraft}
+                  onClick={(e) => e.stopPropagation()}
+                  onChange={(e) => setTitleDraft(e.target.value)}
+                  onBlur={commitTitle}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitTitle();
+                    if (e.key === 'Escape') {
+                      setTitleDraft(milestone.title);
+                      setEditingTitle(false);
+                    }
+                  }}
+                />
+              ) : (
+                <div
+                  className="font-semibold cursor-text hover:bg-black/5 rounded px-1"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setEditingTitle(true);
+                  }}
+                >
+                  {milestone.title}
+                </div>
+              )
+            ) : (
+              <div className="font-semibold">{milestone.title}</div>
+            )}
               <div className="h-2 bg-black/10 rounded-full mt-2 overflow-hidden">
                 <div className="h-full bg-black/40" style={{ width: `${pct}%` }} />
               </div>

--- a/src/MilestoneCard.test.jsx
+++ b/src/MilestoneCard.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import MilestoneCard from './MilestoneCard.jsx';
+
+const milestone = { id: 'm1', title: 'Milestone 1', goal: '', start: '' };
+
+describe('MilestoneCard', () => {
+  it('edits milestone title', () => {
+    const onUpdateMilestone = vi.fn();
+    render(<MilestoneCard milestone={milestone} onUpdateMilestone={onUpdateMilestone} />);
+
+    const title = screen.getByText('Milestone 1');
+    fireEvent.click(title);
+    const input = screen.getByDisplayValue('Milestone 1');
+    fireEvent.change(input, { target: { value: 'Updated Title' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', charCode: 13 });
+
+    expect(onUpdateMilestone).toHaveBeenCalledWith('m1', { title: 'Updated Title' });
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow inline editing of milestone titles with commit on blur/enter
- plumb milestone update handler from parent component
- cover milestone title editing with a new test

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run --environment jsdom` *(fails: 403 Forbidden to fetch vitest package)*

------
https://chatgpt.com/codex/tasks/task_e_68b92d87165c832b87bc8ea13d3ec5e3