### PR TITLE
Avoid draggable on touch devices

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -912,6 +912,7 @@ export function TaskCard({ task: t, team = [], milestones = [], tasks = [], onUp
   const [collapsed, setCollapsed] = useState(true);
   const [touchStartX, setTouchStartX] = useState(null);
   const isMobile = useMemo(() => window.matchMedia('(pointer: coarse)').matches, []);
+  const dragProps = isMobile ? {} : dragHandlers;
   const statusList = ['todo', 'inprogress', 'done'];
   const statusLabel = { todo: 'To Do', inprogress: 'In Progress', done: 'Done' };
   const handleTouchStart = (e) => setTouchStartX(e.touches[0].clientX);
@@ -939,8 +940,9 @@ export function TaskCard({ task: t, team = [], milestones = [], tasks = [], onUp
   };
   return (
     <motion.div
-      {...dragHandlers}
-      className={`rounded-lg border border-black/10 p-2 sm:p-3 shadow-sm text-sm ${t.status === "inprogress" ? "bg-emerald-50" : "bg-white"} ${dragHandlers.draggable ? "cursor-move" : ""}`}
+      data-testid="task-card"
+      {...dragProps}
+      className={`rounded-lg border border-black/10 p-2 sm:p-3 shadow-sm text-sm ${t.status === "inprogress" ? "bg-emerald-50" : "bg-white"} ${dragProps.draggable ? "cursor-move" : ""}`}
       onTouchStart={isMobile ? handleTouchStart : undefined}
       onTouchEnd={isMobile ? handleTouchEnd : undefined}
     >
@@ -1200,9 +1202,10 @@ export function BoardView({ tasks, team, milestones, onUpdate, onDelete, onDragS
               {byCol(c.id).map((t) => { const a = team.find((m)=>m.id===t.assigneeId); const collapsed = isCollapsed(t.id); return (
                 <motion.div
                   key={t.id}
+                  data-testid="task-card"
                   className={`rounded-lg border border-black/10 p-3 shadow-sm ${c.id==='inprogress' ? 'bg-emerald-50' : 'bg-white'}`}
-                  draggable
-                  onDragStart={onDragStart(t.id)}
+                  draggable={!isMobile}
+                  onDragStart={!isMobile ? onDragStart(t.id) : undefined}
                   onTouchStart={isMobile ? handleTouchStart(t.id) : undefined}
                   onTouchEnd={isMobile ? handleTouchEnd(t.id) : undefined}
                 >

--- a/src/BoardView.test.jsx
+++ b/src/BoardView.test.jsx
@@ -41,48 +41,54 @@ describe('BoardView swipe transitions', () => {
 
   it('swipe right from todo moves to inprogress', () => {
     const onUpdate = vi.fn();
-    const { container } = renderBoard('todo', onUpdate);
-    const card = container.querySelector('[draggable="true"]');
+    renderBoard('todo', onUpdate);
+    const card = screen.getByTestId('task-card');
+    expect(card.hasAttribute('draggable')).toBe(false);
     swipe(card, 100);
     expect(onUpdate).toHaveBeenCalledWith('t1', { status: 'inprogress' });
   });
 
   it('swipe left from todo stays at todo', () => {
     const onUpdate = vi.fn();
-    const { container } = renderBoard('todo', onUpdate);
-    const card = container.querySelector('[draggable="true"]');
+    renderBoard('todo', onUpdate);
+    const card = screen.getByTestId('task-card');
+    expect(card.hasAttribute('draggable')).toBe(false);
     swipe(card, -100);
     expect(onUpdate).not.toHaveBeenCalled();
   });
 
   it('swipe right from inprogress moves to done', () => {
     const onUpdate = vi.fn();
-    const { container } = renderBoard('inprogress', onUpdate);
-    const card = container.querySelector('[draggable="true"]');
+    renderBoard('inprogress', onUpdate);
+    const card = screen.getByTestId('task-card');
+    expect(card.hasAttribute('draggable')).toBe(false);
     swipe(card, 100);
     expect(onUpdate).toHaveBeenCalledWith('t1', { status: 'done' });
   });
 
   it('swipe left from inprogress moves to todo', () => {
     const onUpdate = vi.fn();
-    const { container } = renderBoard('inprogress', onUpdate);
-    const card = container.querySelector('[draggable="true"]');
+    renderBoard('inprogress', onUpdate);
+    const card = screen.getByTestId('task-card');
+    expect(card.hasAttribute('draggable')).toBe(false);
     swipe(card, -100);
     expect(onUpdate).toHaveBeenCalledWith('t1', { status: 'todo' });
   });
 
   it('swipe left from done moves to inprogress', () => {
     const onUpdate = vi.fn();
-    const { container } = renderBoard('done', onUpdate);
-    const card = container.querySelector('[draggable="true"]');
+    renderBoard('done', onUpdate);
+    const card = screen.getByTestId('task-card');
+    expect(card.hasAttribute('draggable')).toBe(false);
     swipe(card, -100);
     expect(onUpdate).toHaveBeenCalledWith('t1', { status: 'inprogress' });
   });
 
   it('swipe right from done stays at done', () => {
     const onUpdate = vi.fn();
-    const { container } = renderBoard('done', onUpdate);
-    const card = container.querySelector('[draggable="true"]');
+    renderBoard('done', onUpdate);
+    const card = screen.getByTestId('task-card');
+    expect(card.hasAttribute('draggable')).toBe(false);
     swipe(card, 100);
     expect(onUpdate).not.toHaveBeenCalled();
   });
@@ -108,10 +114,11 @@ describe('BoardView swipe transitions', () => {
         />
       );
     };
-    const { container } = render(<Wrapper />);
-    expect(container.querySelector('select')).toBeNull();
-    expect(container.textContent).toContain('To Do');
-    const card = container.querySelector('[draggable="true"]');
+    render(<Wrapper />);
+    expect(screen.queryByRole('combobox')).toBeNull();
+    expect(screen.getByText('To Do')).toBeInTheDocument();
+    const card = screen.getByTestId('task-card');
+    expect(card.hasAttribute('draggable')).toBe(false);
     fireEvent.touchStart(card, { touches: [{ clientX: 0 }] });
     fireEvent.touchEnd(card, { changedTouches: [{ clientX: 100 }] });
     await screen.findByText('In Progress');

--- a/src/TaskCard.test.jsx
+++ b/src/TaskCard.test.jsx
@@ -90,7 +90,7 @@ describe('TaskCard', () => {
       }));
     });
 
-    const renderWithStatus = (status, onUpdate) =>
+    const renderWithStatus = (status, onUpdate) => {
       render(
         <TaskCard
           task={{ ...sampleTask, status }}
@@ -100,6 +100,8 @@ describe('TaskCard', () => {
           onDuplicate={() => {}}
         />
       );
+      return screen.getByTestId('task-card');
+    };
 
     const swipe = (element, dx) => {
       fireEvent.touchStart(element, { touches: [{ clientX: 0 }] });
@@ -108,43 +110,49 @@ describe('TaskCard', () => {
 
     it('swipe right from todo moves to inprogress', () => {
       const onUpdate = vi.fn();
-      const { container } = renderWithStatus('todo', onUpdate);
-      swipe(container.firstChild, 100);
+      const card = renderWithStatus('todo', onUpdate);
+      expect(card.hasAttribute('draggable')).toBe(false);
+      swipe(card, 100);
       expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { status: 'inprogress' });
     });
 
     it('swipe left from todo stays at todo', () => {
       const onUpdate = vi.fn();
-      const { container } = renderWithStatus('todo', onUpdate);
-      swipe(container.firstChild, -100);
+      const card = renderWithStatus('todo', onUpdate);
+      expect(card.hasAttribute('draggable')).toBe(false);
+      swipe(card, -100);
       expect(onUpdate).not.toHaveBeenCalled();
     });
 
     it('swipe right from inprogress moves to done', () => {
       const onUpdate = vi.fn();
-      const { container } = renderWithStatus('inprogress', onUpdate);
-      swipe(container.firstChild, 100);
+      const card = renderWithStatus('inprogress', onUpdate);
+      expect(card.hasAttribute('draggable')).toBe(false);
+      swipe(card, 100);
       expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { status: 'done' });
     });
 
     it('swipe left from inprogress moves to todo', () => {
       const onUpdate = vi.fn();
-      const { container } = renderWithStatus('inprogress', onUpdate);
-      swipe(container.firstChild, -100);
+      const card = renderWithStatus('inprogress', onUpdate);
+      expect(card.hasAttribute('draggable')).toBe(false);
+      swipe(card, -100);
       expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { status: 'todo' });
     });
 
     it('swipe left from done moves to inprogress', () => {
       const onUpdate = vi.fn();
-      const { container } = renderWithStatus('done', onUpdate);
-      swipe(container.firstChild, -100);
+      const card = renderWithStatus('done', onUpdate);
+      expect(card.hasAttribute('draggable')).toBe(false);
+      swipe(card, -100);
       expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { status: 'inprogress' });
     });
 
     it('swipe right from done stays at done', () => {
       const onUpdate = vi.fn();
-      const { container } = renderWithStatus('done', onUpdate);
-      swipe(container.firstChild, 100);
+      const card = renderWithStatus('done', onUpdate);
+      expect(card.hasAttribute('draggable')).toBe(false);
+      swipe(card, 100);
       expect(onUpdate).not.toHaveBeenCalled();
     });
   });
@@ -174,10 +182,11 @@ describe('TaskCard', () => {
           />
         );
       };
-      const { container } = render(<Wrapper />);
-      expect(container.querySelectorAll('select').length).toBe(1);
+      render(<Wrapper />);
+      expect(screen.getAllByRole('combobox').length).toBe(1);
       expect(screen.getByText('To Do')).toBeInTheDocument();
-      const card = container.firstChild;
+      const card = screen.getByTestId('task-card');
+      expect(card.hasAttribute('draggable')).toBe(false);
       fireEvent.touchStart(card, { touches: [{ clientX: 0 }] });
       fireEvent.touchEnd(card, { changedTouches: [{ clientX: 100 }] });
       await screen.findByText('In Progress');


### PR DESCRIPTION
## Summary
- skip drag handlers on touch so TaskCard no longer sets `draggable` on mobile
- disable dragging in BoardView for mobile and avoid onDragStart handler
- update tests to use test ids and ensure swipes work without `draggable`

## Testing
- ⚠️ `npx vitest run` *(missing vitest package)*

------
https://chatgpt.com/codex/tasks/task_e_68b95f86d5a4832b8ff4882328df4dda