### PR TITLE
Include 14th day in upcoming tasks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,6 +54,8 @@ import {
 
 const SoundContext = createContext(true);
 
+const UPCOMING_DAYS = 15; // include today plus 14 days ahead
+
 // =====================================================
 // Utilities
 // =====================================================
@@ -1445,7 +1447,7 @@ function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
   const upcoming = useMemo(() => {
     const start = new Date();
     start.setHours(0, 0, 0, 0);
-    return [...Array(14)].map((_, i) => {
+    return [...Array(UPCOMING_DAYS)].map((_, i) => {
       const d = new Date(start);
       d.setDate(start.getDate() + i);
       const ds = fmt(d);


### PR DESCRIPTION
## Summary
- use `UPCOMING_DAYS` constant for upcoming task iteration
- extend upcoming task window to include the day 14 days from today

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68c38b467160832baeb97b0af4bb8460