### PR TITLE
Export upcoming days constant for dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,7 +54,6 @@ import {
 
 const SoundContext = createContext(true);
 
-const UPCOMING_DAYS = 15; // include today plus 14 days ahead
 
 // =====================================================
 // Utilities
@@ -1274,7 +1273,7 @@ export function BoardView({ tasks, team, milestones, onUpdate, onDelete, onDragS
 // =====================================================
 // User Dashboard (NEW)
 // =====================================================
-const UPCOMING_DAYS = 15;
+export const UPCOMING_DAYS = 15;
 
 export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
   const [courses, setCourses] = useState(() => loadCourses());


### PR DESCRIPTION
## Summary
- export `UPCOMING_DAYS` constant for user dashboard
- build upcoming tasks window using `Array(UPCOMING_DAYS)`

## Testing
- `npm install` *(fails: 403 Forbidden for @testing-library/jest-dom)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a439a790832b9a10d47c5af5b8df