### PR TITLE
feat: add mobile detection hook

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState, useRef, Fragment, useContext, createContext } from "react";
+import { useIsMobile } from "./hooks/use-is-mobile.js";
 import { AnimatePresence, motion, useAnimation } from "framer-motion";
 import {
   Plus,
@@ -895,7 +896,7 @@ function DepPicker({ task, tasks, onUpdate }) { const [open, setOpen] = useState
 export function TaskCard({ task: t, team = [], milestones = [], tasks = [], onUpdate, onDelete, onDuplicate, onAddLink, onRemoveLink, dragHandlers = {} }) {
   const [collapsed, setCollapsed] = useState(true);
   const [touchStartX, setTouchStartX] = useState(null);
-  const isMobile = useMemo(() => window.matchMedia('(pointer: coarse)').matches, []);
+  const isMobile = useIsMobile();
   const dragProps = isMobile ? {} : dragHandlers;
   const statusList = ['todo', 'inprogress', 'done'];
   const statusLabel = { todo: 'To Do', inprogress: 'In Progress', done: 'Done' };
@@ -1179,7 +1180,7 @@ export function BoardView({ tasks, team, milestones, onUpdate, onDelete, onDragS
   const cols = [ { id: "todo", title: "To Do" }, { id: "inprogress", title: "In Progress" }, { id: "done", title: "Done" } ];
   const taskAssignableMembers = team; const byCol = (id) => tasks.filter((t)=>t.status===id).sort((a,b)=>{ const da=a.dueDate?new Date(a.dueDate).getTime():Number.POSITIVE_INFINITY; const db=b.dueDate?new Date(b.dueDate).getTime():Number.POSITIVE_INFINITY; return da-db; });
   const [collapsedIds, setCollapsedIds] = React.useState(() => new Set(tasks.map((t) => t.id)));
-  const isMobile = React.useMemo(() => window.matchMedia('(pointer: coarse)').matches, []);
+  const isMobile = useIsMobile();
   const touchStartRef = React.useRef({});
   const statusList = ['todo', 'inprogress', 'done'];
   const handleTouchStart = (id) => (e) => { touchStartRef.current[id] = e.touches[0].clientX; };

--- a/src/hooks/use-is-mobile.js
+++ b/src/hooks/use-is-mobile.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.matchMedia('(pointer: coarse)').matches : false
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia('(pointer: coarse)');
+    const handler = (e) => setIsMobile(e.matches);
+    if (mql.addEventListener) {
+      mql.addEventListener('change', handler);
+    } else if (mql.addListener) {
+      mql.addListener(handler);
+    }
+    return () => {
+      if (mql.removeEventListener) {
+        mql.removeEventListener('change', handler);
+      } else if (mql.removeListener) {
+        mql.removeListener(handler);
+      }
+    };
+  }, []);
+
+  return isMobile;
+}
+
+export default useIsMobile;


### PR DESCRIPTION
## Summary
- add `useIsMobile` hook using `matchMedia` change events
- refactor `TaskCard` and `BoardView` to reuse the mobile hook

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a9dc50c8832b8a6616b825092203