### PR TITLE
feat: add interactive checklist for upcoming deadlines

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1512,8 +1512,28 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
                         <li className="text-xs text-black/40">No tasks</li>
                       ) : (
                         tasks.map((t) => (
-                          <li key={t.id} className="text-xs truncate bg-slate-100 rounded px-2 py-1" title={`${t.title} – ${t.courseName}`}>
-                            {t.title}
+                          <li
+                            key={t.id}
+                            className="text-xs flex items-center gap-1 truncate bg-slate-100 rounded px-2 py-1"
+                          >
+                            <input
+                              type="checkbox"
+                              className="rounded border-slate-300"
+                              aria-label={`${t.title} in ${t.courseName}`}
+                              checked={t.status === 'done'}
+                              onChange={(e) =>
+                                updateTask(t.courseId, t.id, {
+                                  status: e.target.checked ? 'done' : 'todo'
+                                })
+                              }
+                            />
+                            <button
+                              onClick={() => setEditing({ courseId: t.courseId, taskId: t.id })}
+                              className="truncate text-left flex-1"
+                              title={`${t.title} – ${t.courseName}`}
+                            >
+                              {t.title} <span className="text-black/60">in {t.courseName}</span>
+                            </button>
                           </li>
                         ))
                       )}

--- a/src/UpcomingDeadlines.test.jsx
+++ b/src/UpcomingDeadlines.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { UserDashboard, UPCOMING_DAYS } from './App.jsx';
 import { fmt } from './utils.js';
@@ -38,8 +38,24 @@ describe('Upcoming Deadlines window', () => {
 
     render(<UserDashboard onOpenCourse={() => {}} onBack={() => {}} initialUserId="u1" />);
 
-    expect(await screen.findByText('Today Task')).toBeInTheDocument();
-    expect(await screen.findByText('Future Task')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Today Task in Course 1' })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Future Task in Course 1' })
+    ).toBeInTheDocument();
     expect(screen.queryByText('Outside Task')).toBeNull();
+
+    const checkbox = await screen.findByRole('checkbox', {
+      name: 'Today Task in Course 1',
+    });
+    expect(checkbox).not.toBeChecked();
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Today Task in Course 1' })
+    );
+    expect(await screen.findByText('Delete')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- show upcoming deadline tasks as checklist with course names
- allow marking tasks complete and open task card from upcoming list
- test upcoming deadlines checklist interactions

## Testing
- `npm test` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68c3ab792e48832ba2643ad6bff9b0fd