### PR TITLE
feat: add interactive checklist for upcoming deadlines

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1449,13 +1449,14 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
   const upcoming = useMemo(() => {
     const start = new Date();
     start.setHours(0, 0, 0, 0);
-    return [...Array(UPCOMING_DAYS)].map((_, i) => {
+    const days = [...Array(UPCOMING_DAYS)].map((_, i) => {
       const d = new Date(start);
       d.setDate(start.getDate() + i);
       const ds = fmt(d);
       const tasks = myTasks.filter((t) => t.dueDate === ds);
       return { date: d, tasks };
     });
+    return days.filter(({ tasks }) => tasks.length > 0);
   }, [myTasks]);
 
   return (
@@ -1497,31 +1498,49 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
       <main className="max-w-7xl mx-auto px-4 py-6 space-y-6">
         <section>
           <h2 className="text-lg font-semibold mb-2">Upcoming Deadlines</h2>
-          {upcoming.every((d) => d.tasks.length === 0) ? (
+          {upcoming.length === 0 ? (
             <div className="text-sm text-black/60">No tasks due in the next 2 weeks.</div>
           ) : (
-            <div className="overflow-x-auto">
-              <div className="flex gap-2 min-w-max sm:min-w-0 sm:grid sm:grid-cols-7">
-                {upcoming.map(({ date, tasks }) => (
-                  <div key={fmt(date)} className="min-w-[10rem] sm:min-w-0 rounded-xl border border-black/10 bg-white p-3 flex flex-col">
-                    <div className="text-xs font-medium mb-1">
-                      {date.toLocaleDateString(undefined, { weekday: 'short', month: 'numeric', day: 'numeric' })}
-                    </div>
-                    <ul className="space-y-1 flex-1">
-                      {tasks.length === 0 ? (
-                        <li className="text-xs text-black/40">No tasks</li>
-                      ) : (
-                        tasks.map((t) => (
-                          <li key={t.id} className="text-xs truncate bg-slate-100 rounded px-2 py-1" title={`${t.title} – ${t.courseName}`}>
-                            {t.title}
-                          </li>
-                        ))
-                      )}
-                    </ul>
+            <ul className="space-y-2">
+              {upcoming.map(({ date, tasks }) => (
+                <li
+                  key={fmt(date)}
+                  data-testid="upcoming-day"
+                  className="rounded-xl border border-black/10 bg-white p-3"
+                >
+                  <div className="text-xs font-medium mb-1">
+                    {date.toLocaleDateString(undefined, { weekday: 'short', month: 'numeric', day: 'numeric' })}
                   </div>
-                ))}
-              </div>
-            </div>
+                  <ul className="space-y-1">
+                    {tasks.map((t) => (
+                      <li
+                        key={t.id}
+                        className="text-xs flex items-center gap-1 truncate bg-slate-100 rounded px-2 py-1"
+                      >
+                        <input
+                          type="checkbox"
+                          className="rounded border-slate-300"
+                          aria-label={`${t.title} in ${t.courseName}`}
+                          checked={t.status === 'done'}
+                          onChange={(e) =>
+                            updateTask(t.courseId, t.id, {
+                              status: e.target.checked ? 'done' : 'todo'
+                            })
+                          }
+                        />
+                        <button
+                          onClick={() => setEditing({ courseId: t.courseId, taskId: t.id })}
+                          className="truncate text-left flex-1"
+                          title={`${t.title} – ${t.courseName}`}
+                        >
+                          {t.title} <span className="text-black/60">in {t.courseName}</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+            </ul>
           )}
         </section>
 

--- a/src/UpcomingDeadlines.test.jsx
+++ b/src/UpcomingDeadlines.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { UserDashboard, UPCOMING_DAYS } from './App.jsx';
 import { fmt } from './utils.js';
@@ -38,8 +38,40 @@ describe('Upcoming Deadlines window', () => {
 
     render(<UserDashboard onOpenCourse={() => {}} onBack={() => {}} initialUserId="u1" />);
 
-    expect(await screen.findByText('Today Task')).toBeInTheDocument();
-    expect(await screen.findByText('Future Task')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Today Task in Course 1' })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Future Task in Course 1' })
+    ).toBeInTheDocument();
     expect(screen.queryByText('Outside Task')).toBeNull();
+
+    const dayCards = await screen.findAllByTestId('upcoming-day');
+    expect(dayCards).toHaveLength(2);
+    const todayLabel = today.toLocaleDateString(undefined, {
+      weekday: 'short',
+      month: 'numeric',
+      day: 'numeric'
+    });
+    const futureLabel = day14.toLocaleDateString(undefined, {
+      weekday: 'short',
+      month: 'numeric',
+      day: 'numeric'
+    });
+    expect(dayCards[0]).toHaveTextContent(todayLabel);
+    expect(dayCards[1]).toHaveTextContent(futureLabel);
+    expect(screen.queryByText('No tasks')).toBeNull();
+
+    const checkbox = await screen.findByRole('checkbox', {
+      name: 'Today Task in Course 1',
+    });
+    expect(checkbox).not.toBeChecked();
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Today Task in Course 1' })
+    );
+    expect(await screen.findByText('Delete')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- show upcoming deadline tasks as checklist with course names
- allow marking tasks complete and open task card from upcoming list
- hide empty dates and stack upcoming days vertically
- test upcoming deadlines checklist interactions

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68c3ab792e48832ba2643ad6bff9b0fd