### PR TITLE
Verify upcoming deadlines ordering and interactions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1502,16 +1502,23 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
           ) : (
             <div className="overflow-x-auto">
               <div className="flex gap-2 min-w-max sm:min-w-0 sm:grid sm:grid-cols-7">
-                {upcoming.map(({ date, tasks }) => (
-                  <div key={fmt(date)} className="min-w-[10rem] sm:min-w-0 rounded-xl border border-black/10 bg-white p-3 flex flex-col">
-                    <div className="text-xs font-medium mb-1">
-                      {date.toLocaleDateString(undefined, { weekday: 'short', month: 'numeric', day: 'numeric' })}
-                    </div>
-                    <ul className="space-y-1 flex-1">
-                      {tasks.length === 0 ? (
-                        <li className="text-xs text-black/40">No tasks</li>
-                      ) : (
-                        tasks.map((t) => (
+                {upcoming
+                  .filter(({ tasks }) => tasks.length > 0)
+                  .map(({ date, tasks }) => (
+                    <div
+                      key={fmt(date)}
+                      data-testid="upcoming-day"
+                      className="min-w-[10rem] sm:min-w-0 rounded-xl border border-black/10 bg-white p-3 flex flex-col"
+                    >
+                      <div className="text-xs font-medium mb-1">
+                        {date.toLocaleDateString(undefined, {
+                          weekday: 'short',
+                          month: 'numeric',
+                          day: 'numeric'
+                        })}
+                      </div>
+                      <ul className="space-y-1 flex-1">
+                        {tasks.map((t) => (
                           <li
                             key={t.id}
                             className="text-xs flex items-center gap-1 truncate bg-slate-100 rounded px-2 py-1"
@@ -1535,11 +1542,10 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
                               {t.title} <span className="text-black/60">in {t.courseName}</span>
                             </button>
                           </li>
-                        ))
-                      )}
-                    </ul>
-                  </div>
-                ))}
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
               </div>
             </div>
           )}

--- a/src/UpcomingDeadlines.test.jsx
+++ b/src/UpcomingDeadlines.test.jsx
@@ -22,6 +22,16 @@ describe('Upcoming Deadlines window', () => {
     day14.setDate(today.getDate() + (UPCOMING_DAYS - 1));
     const day15 = new Date();
     day15.setDate(today.getDate() + UPCOMING_DAYS);
+    const todayLabel = today.toLocaleDateString(undefined, {
+      weekday: 'short',
+      month: 'numeric',
+      day: 'numeric',
+    });
+    const futureLabel = day14.toLocaleDateString(undefined, {
+      weekday: 'short',
+      month: 'numeric',
+      day: 'numeric',
+    });
 
     const courses = [{
       course: { id: 'c1', name: 'Course 1' },
@@ -36,7 +46,15 @@ describe('Upcoming Deadlines window', () => {
 
     localStorage.setItem('healthPM:courses:v1', JSON.stringify(courses));
 
-    render(<UserDashboard onOpenCourse={() => {}} onBack={() => {}} initialUserId="u1" />);
+    render(
+      <UserDashboard onOpenCourse={() => {}} onBack={() => {}} initialUserId="u1" />
+    );
+
+    const days = await screen.findAllByTestId('upcoming-day');
+    expect(days).toHaveLength(2);
+    expect(days[0]).toHaveTextContent(todayLabel);
+    expect(days[1]).toHaveTextContent(futureLabel);
+    expect(screen.queryByText('No tasks')).toBeNull();
 
     expect(
       await screen.findByRole('button', { name: 'Today Task in Course 1' })


### PR DESCRIPTION
## Summary
- Display only days with tasks in the Upcoming Deadlines section and tag them for testing
- Extend UpcomingDeadlines.test to ensure day cards are chronological, omit empty days, and support interactions

## Testing
- `npm install` *(fails: 403 Forbidden when fetching @testing-library/jest-dom)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3af908274832b9633525cbd1f29a8