### PR TITLE
refactor: move team members UI into dedicated component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,6 @@ import { AnimatePresence, motion, useAnimation } from "framer-motion";
 import {
   Plus,
   Calendar,
-  Users,
   ClipboardList,
   ListChecks,
   Download,
@@ -28,6 +27,7 @@ import {
 import { doc, getDoc, setDoc } from "firebase/firestore";
 import { db } from "./firebase.js";
 import MilestoneCard from "./MilestoneCard.jsx";
+import TeamMembersSection from "./components/TeamMembersSection.jsx";
 import pkg from "../package.json";
 import {
   uid,
@@ -313,7 +313,6 @@ function CoursePMApp({ boot, isTemplateLabel = false, onBack, onStateChange, peo
   const [milestoneFilter, setMilestoneFilter] = useState("all");
   const [listTab, setListTab] = useState("active");
   const [milestonesCollapsed, setMilestonesCollapsed] = useState(true);
-  const [membersEditing, setMembersEditing] = useState(false);
   const [saveState, setSaveState] = useState('saved');
   const firstRun = useRef(true);
 
@@ -595,89 +594,18 @@ const tasksDone = useMemo(() => {
         </section>
 
         {/* Team Members FIRST */}
-        <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
-          <div className="flex items-center justify-between mb-2">
-            <h2 className="font-semibold flex items-center gap-2"><Users size={18}/> Team Members</h2>
-            <div className="flex items-center gap-2">
-              <select
-                value=""
-                onChange={(e)=>{ if(e.target.value) { addExistingMember(e.target.value); e.target.value=''; } }}
-                className="text-sm border rounded px-2 py-1"
-              >
-                <option value="">Add existing...</option>
-                {people.filter((p)=>!team.some((m)=>m.id===p.id)).map((p)=>(
-                  <option key={p.id} value={p.id}>{p.name}</option>
-                ))}
-              </select>
-              <button onClick={() => addMember()} className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"><UserPlus size={16}/> Add Member</button>
-              <button
-                onClick={() => setMembersEditing(v => !v)}
-                className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
-              >
-                {membersEditing ? 'Done' : 'Edit Members'}
-              </button>
-            </div>
-          </div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-3">
-            {team.map((m) => (
-              <div key={m.id} className="rounded-xl border border-black/10 p-3 flex items-center justify-between">
-                <div className="flex items-center gap-2 min-w-0">
-                  <Avatar name={m.name} roleType={m.roleType} avatar={m.avatar} />
-                  {membersEditing ? (
-                    <InlineText
-                      value={m.name}
-                      onChange={(v) => updateMember(m.id, { name: v })}
-                      className="font-medium truncate"
-                    />
-                  ) : (
-                    <button
-                      onClick={() => openUser(m.id)}
-                      className="font-medium truncate text-left hover:underline"
-                    >
-                      {m.name}
-                    </button>
-                  )}
-                </div>
-                <div className="flex items-center gap-2">
-                  {membersEditing ? (
-                    <Fragment>
-                      <select
-                        value={m.roleType}
-                        onChange={(e) => updateMember(m.id, { roleType: e.target.value })}
-                        className="border rounded px-2 py-1 text-sm"
-                      >
-                        {Object.keys(rolePalette).map((r) => (
-                          <option key={r} value={r}>
-                            {r}
-                          </option>
-                        ))}
-                      </select>
-                      {(m.roleType === "LD" || m.roleType === "SME") && (
-                        <label className="text-xs inline-flex items-center gap-1 cursor-pointer">
-                          <input
-                            type="checkbox"
-                            checked={(m.roleType === "LD" ? state.course.courseLDIds : state.course.courseSMEIds).includes(m.id)}
-                            onChange={() => toggleCourseWide(m.roleType, m.id)}
-                          />
-                          course-wide
-                        </label>
-                      )}
-                      <button
-                        className="text-black/40 hover:text-red-500"
-                        title="Remove member"
-                        onClick={() => deleteMember(m.id)}
-                      >
-                        <Trash2 size={16} />
-                      </button>
-                    </Fragment>
-                  ) : (
-                    <span className="text-sm">{m.roleType}</span>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
+        <TeamMembersSection
+          team={team}
+          people={people}
+          onAddMember={addMember}
+          onAddExistingMember={addExistingMember}
+          onUpdateMember={updateMember}
+          onDeleteMember={deleteMember}
+          onToggleCourseWide={toggleCourseWide}
+          onOpenUser={openUser}
+          courseLDIds={state.course.courseLDIds}
+          courseSMEIds={state.course.courseSMEIds}
+        />
         {/* Milestones */}
           <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
             <div

--- a/src/components/TeamMembersSection.jsx
+++ b/src/components/TeamMembersSection.jsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { Users, UserPlus, Trash2 } from "lucide-react";
+import { rolePalette, roleColor } from "../utils.js";
+
+const Avatar = ({ name, roleType, avatar, className = "w-6 h-6 text-[10px]" }) => (
+  <span
+    className={`inline-flex items-center justify-center rounded-full font-medium ${className}`}
+    style={avatar ? { background: roleColor(roleType) } : { background: roleColor(roleType), color: "#fff" }}
+    title={name}
+  >
+    {avatar || name.split(" ").map((w) => w[0]).join("")}
+  </span>
+);
+
+function TeamMemberCard({
+  member,
+  courseLDIds = [],
+  courseSMEIds = [],
+  onUpdate,
+  onDelete,
+  onToggleCourseWide,
+  onOpenUser,
+}) {
+  const courseWide = member.roleType === "LD" ? courseLDIds : courseSMEIds;
+  return (
+    <div className="group rounded-xl border border-black/10 p-3 flex items-center justify-between">
+      <div className="flex items-center gap-2 min-w-0">
+        <Avatar name={member.name} roleType={member.roleType} avatar={member.avatar} />
+        <button
+          onClick={() => onOpenUser(member.id)}
+          className="font-medium truncate text-left hover:underline"
+        >
+          {member.name}
+        </button>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-sm group-hover:hidden">{member.roleType}</span>
+        <div className="hidden group-hover:flex items-center gap-2">
+          <select
+            value={member.roleType}
+            onChange={(e) => onUpdate(member.id, { roleType: e.target.value })}
+            className="border rounded px-2 py-1 text-sm"
+          >
+            {Object.keys(rolePalette).map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+          {(member.roleType === "LD" || member.roleType === "SME") && (
+            <label className="text-xs inline-flex items-center gap-1 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={courseWide.includes(member.id)}
+                onChange={() => onToggleCourseWide(member.roleType, member.id)}
+              />
+              course-wide
+            </label>
+          )}
+          <button
+            className="text-black/40 hover:text-red-500"
+            title="Remove member"
+            onClick={() => onDelete(member.id)}
+          >
+            <Trash2 size={16} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function TeamMembersSection({
+  team = [],
+  people = [],
+  onAddMember,
+  onAddExistingMember,
+  onUpdateMember,
+  onDeleteMember,
+  onToggleCourseWide,
+  onOpenUser,
+  courseLDIds = [],
+  courseSMEIds = [],
+}) {
+  return (
+    <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="font-semibold flex items-center gap-2">
+          <Users size={18} /> Team Members
+        </h2>
+        <div className="flex items-center gap-2">
+          <select
+            value=""
+            onChange={(e) => {
+              if (e.target.value) {
+                onAddExistingMember(e.target.value);
+                e.target.value = "";
+              }
+            }}
+            className="text-sm border rounded px-2 py-1"
+          >
+            <option value="">Add existing...</option>
+            {people
+              .filter((p) => !team.some((m) => m.id === p.id))
+              .map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+          </select>
+          <button
+            onClick={onAddMember}
+            className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
+          >
+            <UserPlus size={16} /> Add Member
+          </button>
+        </div>
+      </div>
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {team.map((m) => (
+          <TeamMemberCard
+            key={m.id}
+            member={m}
+            courseLDIds={courseLDIds}
+            courseSMEIds={courseSMEIds}
+            onUpdate={onUpdateMember}
+            onDelete={onDeleteMember}
+            onToggleCourseWide={onToggleCourseWide}
+            onOpenUser={onOpenUser}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export { TeamMemberCard };
+


### PR DESCRIPTION
## Summary
- extract team members section into new TeamMembersSection component with TeamMemberCard subcomponent
- show per-member editing controls on hover and remove global edit toggle
- update App.jsx to use TeamMembersSection

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b0e2bad8832ba7752bae76a84725