### PR TITLE
feat: colorize milestone progress bar

### DIFF
--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -39,6 +39,15 @@ export default function MilestoneCard({
     return { done, pct, tasksSorted };
   }, [tasks]);
 
+  const progressColor = useMemo(() => {
+    const start = [236, 72, 153];
+    const end = [16, 185, 129];
+    const t = pct / 100;
+    const rgb = start.map((s, i) => Math.round(s + (end[i] - s) * t));
+    const toHex = (v) => v.toString(16).padStart(2, '0');
+    return `#${rgb.map(toHex).join('')}`;
+  }, [pct]);
+
     return (
       <details className="group rounded-xl border border-black/10 bg-white">
         <summary className="cursor-pointer select-none p-4 flex items-center justify-between gap-2 list-none [&::-webkit-details-marker]:hidden">
@@ -77,7 +86,10 @@ export default function MilestoneCard({
               <div className="font-semibold">{milestone.title}</div>
             )}
               <div className="h-2 bg-black/10 rounded-full mt-2 overflow-hidden">
-                <div className="h-full bg-black/40" style={{ width: `${pct}%` }} />
+                <div
+                  className="h-full transition-colors"
+                  style={{ width: `${pct}%`, backgroundColor: progressColor }}
+                />
               </div>
             </div>
           </div>

--- a/src/MilestoneCard.test.jsx
+++ b/src/MilestoneCard.test.jsx
@@ -17,5 +17,35 @@ describe('MilestoneCard', () => {
 
     expect(onUpdateMilestone).toHaveBeenCalledWith('m1', { title: 'Updated Title' });
   });
+
+  it('renders progress bar color at 0%', () => {
+    const tasks = [
+      { id: 't1', status: 'todo' },
+      { id: 't2', status: 'todo' },
+    ];
+    const { container } = render(<MilestoneCard milestone={milestone} tasks={tasks} />);
+    const progressBar = container.querySelector('.h-2').firstElementChild;
+    expect(progressBar.style.backgroundColor).toBe('rgb(236, 72, 153)');
+  });
+
+  it('renders progress bar color at 50%', () => {
+    const tasks = [
+      { id: 't1', status: 'done' },
+      { id: 't2', status: 'todo' },
+    ];
+    const { container } = render(<MilestoneCard milestone={milestone} tasks={tasks} />);
+    const progressBar = container.querySelector('.h-2').firstElementChild;
+    expect(progressBar.style.backgroundColor).toBe('rgb(126, 129, 141)');
+  });
+
+  it('renders progress bar color at 100%', () => {
+    const tasks = [
+      { id: 't1', status: 'done' },
+      { id: 't2', status: 'done' },
+    ];
+    const { container } = render(<MilestoneCard milestone={milestone} tasks={tasks} />);
+    const progressBar = container.querySelector('.h-2').firstElementChild;
+    expect(progressBar.style.backgroundColor).toBe('rgb(16, 185, 129)');
+  });
 });
 


### PR DESCRIPTION
## Summary
- interpolate progress bar color from pink to green based on completion percentage
- test milestone card progress bar colors at 0%, 50% and 100%

## Testing
- `npm test` *(fails: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c3da952cc4832b8c4091ed15fed0ae