### PR TITLE
Replace swipe gestures with accessible status menus

### DIFF
--- a/src/TaskCard.test.jsx
+++ b/src/TaskCard.test.jsx
@@ -78,7 +78,7 @@ describe('TaskCard', () => {
     expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { milestoneId: 'm2' });
   });
 
-  describe('swipe status transitions', () => {
+  describe('mobile status selection', () => {
     beforeAll(() => {
       window.matchMedia = window.matchMedia || (() => ({
         matches: true,
@@ -100,76 +100,39 @@ describe('TaskCard', () => {
           onDuplicate={() => {}}
         />
       );
-      return screen.getByTestId('task-card');
+      fireEvent.click(screen.getByRole('button', { name: /status/i }));
+      return screen.getByLabelText('Status');
     };
 
-    const swipe = (element, dx) => {
-      fireEvent.touchStart(element, { touches: [{ clientX: 0 }] });
-      fireEvent.touchEnd(element, { changedTouches: [{ clientX: dx }] });
-    };
-
-    it('swipe right from todo moves to inprogress', () => {
+    it('changes from todo to inprogress', () => {
       const onUpdate = vi.fn();
-      const card = renderWithStatus('todo', onUpdate);
-      expect(card.hasAttribute('draggable')).toBe(false);
-      swipe(card, 100);
+      const select = renderWithStatus('todo', onUpdate);
+      fireEvent.change(select, { target: { value: 'inprogress' } });
       expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { status: 'inprogress' });
     });
 
-    it('swipe left from todo stays at todo', () => {
+    it('changes from inprogress to done', () => {
       const onUpdate = vi.fn();
-      const card = renderWithStatus('todo', onUpdate);
-      expect(card.hasAttribute('draggable')).toBe(false);
-      swipe(card, -100);
-      expect(onUpdate).not.toHaveBeenCalled();
-    });
-
-    it('swipe right from inprogress moves to done', () => {
-      const onUpdate = vi.fn();
-      const card = renderWithStatus('inprogress', onUpdate);
-      expect(card.hasAttribute('draggable')).toBe(false);
-      swipe(card, 100);
+      const select = renderWithStatus('inprogress', onUpdate);
+      fireEvent.change(select, { target: { value: 'done' } });
       expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { status: 'done' });
     });
 
-    it('swipe left from inprogress moves to todo', () => {
+    it('changes from inprogress back to todo', () => {
       const onUpdate = vi.fn();
-      const card = renderWithStatus('inprogress', onUpdate);
-      expect(card.hasAttribute('draggable')).toBe(false);
-      swipe(card, -100);
+      const select = renderWithStatus('inprogress', onUpdate);
+      fireEvent.change(select, { target: { value: 'todo' } });
       expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { status: 'todo' });
     });
 
-    it('swipe left from done moves to inprogress', () => {
+    it('changes from done back to inprogress', () => {
       const onUpdate = vi.fn();
-      const card = renderWithStatus('done', onUpdate);
-      expect(card.hasAttribute('draggable')).toBe(false);
-      swipe(card, -100);
+      const select = renderWithStatus('done', onUpdate);
+      fireEvent.change(select, { target: { value: 'inprogress' } });
       expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { status: 'inprogress' });
     });
 
-    it('swipe right from done stays at done', () => {
-      const onUpdate = vi.fn();
-      const card = renderWithStatus('done', onUpdate);
-      expect(card.hasAttribute('draggable')).toBe(false);
-      swipe(card, 100);
-      expect(onUpdate).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('mobile status control', () => {
-    beforeAll(() => {
-      window.matchMedia = window.matchMedia || (() => ({
-        matches: true,
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        addListener: () => {},
-        removeListener: () => {},
-        dispatchEvent: () => false,
-      }));
-    });
-
-    it('replaces status dropdown with pill and updates text on swipe', async () => {
+    it('updates button text after selection', async () => {
       const Wrapper = () => {
         const [task, setTask] = useState(sampleTask);
         return (
@@ -184,12 +147,13 @@ describe('TaskCard', () => {
       };
       render(<Wrapper />);
       expect(screen.getAllByRole('combobox').length).toBe(1);
-      expect(screen.getByText('To Do')).toBeInTheDocument();
-      const card = screen.getByTestId('task-card');
-      expect(card.hasAttribute('draggable')).toBe(false);
-      fireEvent.touchStart(card, { touches: [{ clientX: 0 }] });
-      fireEvent.touchEnd(card, { changedTouches: [{ clientX: 100 }] });
-      await screen.findByText('In Progress');
+      const button = screen.getByRole('button', { name: /status/i });
+      expect(button).toHaveTextContent('To Do');
+      fireEvent.click(button);
+      fireEvent.change(screen.getByLabelText('Status'), {
+        target: { value: 'inprogress' },
+      });
+      await screen.findByRole('button', { name: /status: in progress/i });
     });
   });
 });


### PR DESCRIPTION
## Summary
- replace swipe-based status changes with a button+select menu for TaskCard on mobile
- add per-card status menu in BoardView and remove swipe handlers
- update mobile tests to use button/select interactions instead of swipes

## Testing
- `npm test` *(fails: vitest not found after dependency install error)*

------
https://chatgpt.com/codex/tasks/task_e_68c55be03f5c832b87262ccbd286c9db