### PR TITLE
feat: enlarge milestone section text on mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -701,7 +701,7 @@ const tasksDone = useMemo(() => {
           courseSMEIds={state.course.courseSMEIds}
         />
         {/* Milestones */}
-          <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
+          <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm text-base sm:text-sm">
             <div
               className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-2 px-1 cursor-pointer"
               onClick={() => setMilestonesCollapsed(v => !v)}


### PR DESCRIPTION
## Summary
- enlarge text in Milestones section on mobile by applying `text-base` and reverting to `text-sm` on small screens and up

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ab17fc20832ba9880962e083366c