### PR TITLE
feat: add Inter font globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    />
     <title>DART — Design & Development Accountability Tracker</title>
   </head>
   <body class="antialiased">

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@ html, body, #root {
   height: 100%;
 }
 body {
-  @apply bg-slate-50 text-slate-900;
+  @apply bg-slate-50 text-slate-900 font-sans;
 }
 
 @media (max-width: 640px) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,9 @@ export default {
       screens: {
         xs: "475px",
       },
+      fontFamily: {
+        sans: ["Inter", "sans-serif"],
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- load Inter Google Font in `index.html`
- configure Tailwind to use Inter as sans-serif default
- apply `font-sans` globally for consistent typography

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden for @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b04abaf8832b8bdf53145e1bd38a