### PR TITLE
feat: integrate tailwind forms plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "autoprefixer": "^10.4.17",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.4",
+    "@tailwindcss/forms": "^0.5.7",
     "vite": "^5.2.0",
     "vitest": "^1.5.0",
     "@testing-library/react": "^14.0.0",

--- a/src/components/AddHoliday.jsx
+++ b/src/components/AddHoliday.jsx
@@ -10,7 +10,6 @@ export default function AddHoliday({ onAdd }) {
         type="date"
         value={d}
         onChange={(e) => setD(e.target.value)}
-        className="border rounded px-2 py-1"
       />
       <button
         onClick={() => {

--- a/src/components/DepPicker.jsx
+++ b/src/components/DepPicker.jsx
@@ -23,7 +23,6 @@ export default function DepPicker({ task, tasks, onUpdate }) {
               onUpdate(task.id, { depTaskId: val });
               setOpen(false);
             }}
-            className="border rounded px-2 py-1"
           >
             <option value="">— none —</option>
             {peers.map((p) => (

--- a/src/components/DocumentInput.jsx
+++ b/src/components/DocumentInput.jsx
@@ -25,7 +25,7 @@ export default function DocumentInput({ onAdd }) {
           if (e.key === "Enter") add();
         }}
         placeholder="Paste link and press Enter"
-        className="flex-1 border rounded px-1.5 py-1"
+        className="flex-1"
       />
       <button
         onClick={add}

--- a/src/components/InlineText.jsx
+++ b/src/components/InlineText.jsx
@@ -27,7 +27,7 @@ export default function InlineText({ value, onChange, className = "", placeholde
         <motion.textarea
           key="edit"
           autoFocus
-          className={`w-full rounded border border-black/10 bg-white px-2 py-1 outline-none ${className}`}
+          className={`w-full outline-none ${className}`}
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onBlur={commit}
@@ -46,7 +46,7 @@ export default function InlineText({ value, onChange, className = "", placeholde
         <motion.input
           key="edit"
           autoFocus
-          className={`w-full rounded border border-black/10 bg-white px-2 py-1 outline-none ${className}`}
+          className={`w-full outline-none ${className}`}
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onBlur={commit}

--- a/src/components/LinksEditor.jsx
+++ b/src/components/LinksEditor.jsx
@@ -53,7 +53,7 @@ export function LinksEditor({ links = [], onAdd, onRemove }) {
             if (e.key === "Enter") add();
           }}
           placeholder="Paste link & press Enter"
-          className="w-full border rounded px-2 py-1 text-sm"
+          className="w-full text-sm"
         />
         <button
           onClick={add}

--- a/src/components/TaskModal.jsx
+++ b/src/components/TaskModal.jsx
@@ -72,7 +72,6 @@ export default function TaskModal({ task, courseId, courses, onChangeCourse, tas
             <select
               value={courseId}
               onChange={(e) => onChangeCourse(e.target.value)}
-              className="border rounded px-1.5 py-1"
             >
               {courses.map((c) => (
                 <option key={c.course.id} value={c.course.id}>
@@ -84,7 +83,6 @@ export default function TaskModal({ task, courseId, courses, onChangeCourse, tas
           <select
             value={task.milestoneId}
             onChange={(e) => onUpdate(task.id, { milestoneId: e.target.value })}
-            className="border rounded px-1.5 py-1"
           >
             {milestones.map((m) => (
               <option key={m.id} value={m.id}>
@@ -101,7 +99,6 @@ export default function TaskModal({ task, courseId, courses, onChangeCourse, tas
             <select
               value={task.assigneeId || ""}
               onChange={(e) => onUpdate(task.id, { assigneeId: e.target.value || null })}
-              className="border rounded px-1.5 py-1"
             >
               <option value="">Unassigned</option>
               {team.map((m) => (
@@ -114,7 +111,7 @@ export default function TaskModal({ task, courseId, courses, onChangeCourse, tas
           <select
             value={task.status}
             onChange={(e) => onUpdate(task.id, { status: e.target.value })}
-            className={`border rounded px-1.5 py-1 ${statusBg(task.status)}`}
+            className={statusBg(task.status)}
           >
             <option value="todo">To Do</option>
             <option value="inprogress">In Progress</option>
@@ -130,7 +127,7 @@ export default function TaskModal({ task, courseId, courses, onChangeCourse, tas
                 value={task.startDate || ""}
                 onChange={(e) => onUpdate(task.id, { startDate: e.target.value })}
                 disabled={task.status === "todo"}
-                className={`border rounded px-1.5 py-1 ${task.status === "todo" ? "bg-slate-50 text-slate-500" : ""}`}
+                className={task.status === "todo" ? "bg-slate-50 text-slate-500" : ""}
               />
             )}
           </div>
@@ -141,7 +138,7 @@ export default function TaskModal({ task, courseId, courses, onChangeCourse, tas
               min={0}
               value={task.workDays ?? 0}
               onChange={(e) => onUpdate(task.id, { workDays: Number(e.target.value) })}
-              className="w-20 border rounded px-1.5 py-1"
+              className="w-20"
             />
           </div>
           <div className="basis-full w-full">

--- a/src/components/TeamMembersSection.jsx
+++ b/src/components/TeamMembersSection.jsx
@@ -30,7 +30,7 @@ function TeamMemberCard({
           <select
             value={member.roleType}
             onChange={(e) => onUpdate(member.id, { roleType: e.target.value })}
-            className="border rounded px-2 py-1 text-sm"
+            className="text-sm"
           >
             {Object.keys(rolePalette).map((r) => (
               <option key={r} value={r}>
@@ -89,7 +89,7 @@ export default function TeamMembersSection({
                 e.target.value = "";
               }
             }}
-            className="text-sm border rounded px-2 py-1"
+            className="text-sm"
           >
             <option value="">Add existing...</option>
             {people

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+import forms from "@tailwindcss/forms";
+
 export default {
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
@@ -11,5 +13,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [forms],
 };


### PR DESCRIPTION
## Summary
- install and enable `@tailwindcss/forms`
- simplify form element styles to rely on plugin defaults

## Testing
- `npm install` *(fails: 403 Forbidden for @tailwindcss/forms)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b0faec20832b84480da5e7c46bb4