### PR TITLE
Prevent horizontal overflow and allow header wrapping

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1363,7 +1363,7 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
   return (
     <div className="min-h-screen bg-gradient-to-br from-white via-slate-50 to-slate-100 text-slate-900">
       <header className="sticky top-0 z-20 backdrop-blur supports-[backdrop-filter]:bg-white/60 bg-white/80 border-b border-black/5">
-        <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between gap-3">
+        <div className="max-w-7xl mx-auto px-4 py-3 flex flex-wrap sm:flex-nowrap items-center justify-between gap-3">
           <div className="flex items-center gap-3 min-w-0">
             {onBack && (
               <button

--- a/styles/app.css
+++ b/styles/app.css
@@ -16,7 +16,7 @@
   --gradient: linear-gradient(135deg,#0ea5e9,#22c55e);
 }
 *{box-sizing:border-box}
-html,body{height:100%;margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text)}
+ html,body{height:100%;margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text);overflow-x:hidden}
 a{color:#93c5fd}
 button{cursor:pointer}
 button:focus, input:focus, select:focus, textarea:focus{outline:2px solid var(--ring);outline-offset:2px}


### PR DESCRIPTION
## Summary
- enable wrapping of dashboard header content on narrow screens
- hide global horizontal overflow to stop sideways scrolling

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b874f6cc832b8dc644ea7ea196f3