### PR TITLE
Synchronize milestones collapse state with device type

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -295,10 +295,14 @@ function CoursePMApp({ boot, isTemplateLabel = false, onBack, onStateChange, peo
   const [view, setView] = useState("board");
   const [milestoneFilter, setMilestoneFilter] = useState("all");
   const [listTab, setListTab] = useState("active");
-  const [milestonesCollapsed, setMilestonesCollapsed] = useState(true);
+  const isMobile = useIsMobile();
+  const [milestonesCollapsed, setMilestonesCollapsed] = useState(isMobile);
   const [saveState, setSaveState] = useState('saved');
   const firstRun = useRef(true);
-  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    setMilestonesCollapsed(isMobile);
+  }, [isMobile]);
 
   useEffect(() => {
     setState((s) => ({


### PR DESCRIPTION
## Summary
- Initialize `milestonesCollapsed` using `useIsMobile` to start expanded on desktop and collapsed on mobile
- Sync `milestonesCollapsed` when `isMobile` changes for responsive resizing

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden fetching @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68c792bda81c832bba7d56c21d793ea1