### PR TITLE
feat: improve user tab layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1417,7 +1417,7 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
             </button>
           ))}
         </div>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-6">
           {activeTab === 'deadlines' && (
             <SectionCard title="Upcoming Deadlines">
               {upcoming.every((d) => d.tasks.length === 0) ? (

--- a/src/components/SectionCard.jsx
+++ b/src/components/SectionCard.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-export default function SectionCard({ title, actions, children }) {
+export default function SectionCard({ title, actions, children, className = '' }) {
   return (
-    <section className="rounded-xl border bg-white p-4 shadow-sm">
+    <section className={`rounded-xl border bg-white p-4 shadow-sm ${className}`}>
       <div className="flex items-center justify-between mb-2">
         <h2 className="text-lg font-semibold">{title}</h2>
         {actions}


### PR DESCRIPTION
## Summary
- remove desktop grid forcing two columns in App user tabs
- allow SectionCard layouts to be customized via `className`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c79f1daef0832b8da05fa22b4bd4dd