### PR TITLE
Enable assignee editing in collapsed tasks and color milestone progress

### DIFF
--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -39,6 +39,8 @@ export default function MilestoneCard({
     return { done, pct, tasksSorted };
   }, [tasks]);
 
+  const progressColor = `hsl(${330 + (pct / 100) * (120 - 330)}, 70%, 50%)`;
+
     return (
       <details className="group rounded-xl border border-black/10 bg-white">
         <summary className="cursor-pointer select-none p-4 flex items-center justify-between gap-2 list-none [&::-webkit-details-marker]:hidden">
@@ -77,7 +79,11 @@ export default function MilestoneCard({
               <div className="font-semibold">{milestone.title}</div>
             )}
               <div className="h-2 bg-black/10 rounded-full mt-2 overflow-hidden">
-                <div className="h-full bg-black/40" style={{ width: `${pct}%` }} />
+                <div
+                  data-testid="progress-fill"
+                  className="h-full"
+                  style={{ width: `${pct}%`, backgroundColor: progressColor }}
+                />
               </div>
             </div>
           </div>

--- a/src/MilestoneCard.test.jsx
+++ b/src/MilestoneCard.test.jsx
@@ -17,5 +17,18 @@ describe('MilestoneCard', () => {
 
     expect(onUpdateMilestone).toHaveBeenCalledWith('m1', { title: 'Updated Title' });
   });
+
+  it('colors progress bar based on completion', () => {
+    const tasks = [
+      { id: 't1', status: 'done' },
+      { id: 't2', status: 'todo' },
+    ];
+    render(<MilestoneCard milestone={milestone} tasks={tasks} />);
+    const pct = 50;
+    const hue = 330 + (pct / 100) * (120 - 330);
+    const color = `hsl(${hue}, 70%, 50%)`;
+    const bar = screen.getByTestId('progress-fill');
+    expect(bar.getAttribute('style')).toContain(`background-color: ${color}`);
+  });
 });
 

--- a/src/TaskCard.jsx
+++ b/src/TaskCard.jsx
@@ -79,6 +79,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <select
+            aria-label="Milestone"
             value={t.milestoneId}
             onChange={(e) => update(t.id, { milestoneId: e.target.value })}
             className="mb-1 text-sm border rounded px-1 py-0.5"
@@ -173,9 +174,19 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
               ) : (
                 <span className="text-black/40">—</span>
               )}
-              <span className="truncate">
-                {a ? `${a.name} (${a.roleType})` : 'Unassigned'}
-              </span>
+              <select
+                aria-label="Assignee"
+                value={t.assigneeId || ''}
+                onChange={(e) => update(t.id, { assigneeId: e.target.value || null })}
+                className="border rounded px-1.5 py-1"
+              >
+                <option value="">Unassigned</option>
+                {team.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.name} ({m.roleType})
+                  </option>
+                ))}
+              </select>
             </div>
             <div className="flex items-center gap-2">
               <DuePill date={t.dueDate} status={t.status} />
@@ -238,6 +249,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                 <span className="text-black/40">—</span>
               )}
               <select
+                aria-label="Assignee"
                 value={t.assigneeId || ''}
                 onChange={(e) => update(t.id, { assigneeId: e.target.value || null })}
                 className="border rounded px-1.5 py-1"

--- a/src/TaskCard.test.jsx
+++ b/src/TaskCard.test.jsx
@@ -31,7 +31,7 @@ describe('TaskCard', () => {
     );
 
     // milestone select is visible by default
-    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByLabelText('Milestone')).toBeInTheDocument();
 
     const toggleBtn = screen.getByTitle(/expand/i);
     fireEvent.click(toggleBtn);
@@ -74,8 +74,29 @@ describe('TaskCard', () => {
       />
     );
 
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'm2' } });
+    fireEvent.change(screen.getByLabelText('Milestone'), { target: { value: 'm2' } });
     expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { milestoneId: 'm2' });
+  });
+
+  it('updates assignee while collapsed', () => {
+    const onUpdate = vi.fn();
+    const team = [
+      { id: 'u1', name: 'User One', roleType: 'Dev' },
+      { id: 'u2', name: 'User Two', roleType: 'QA' },
+    ];
+    render(
+      <TaskCard
+        task={{ ...sampleTask, assigneeId: 'u1' }}
+        milestones={milestones}
+        team={team}
+        onUpdate={onUpdate}
+        onDelete={() => {}}
+        onDuplicate={() => {}}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Assignee'), { target: { value: 'u2' } });
+    expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { assigneeId: 'u2' });
   });
 
   describe('mobile status selection', () => {
@@ -146,7 +167,7 @@ describe('TaskCard', () => {
         );
       };
       render(<Wrapper />);
-      expect(screen.getAllByRole('combobox').length).toBe(1);
+      expect(screen.getAllByRole('combobox').length).toBe(2);
       const button = screen.getByRole('button', { name: /status/i });
       expect(button).toHaveTextContent('To Do');
       fireEvent.click(button);


### PR DESCRIPTION
## Summary
- Allow changing task assignee directly from a collapsed task card
- Color milestone progress bars from pink toward green based on completion
- Expand test coverage for new assignee control and progress bar coloring

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden fetching @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a9942bb8832baa709ffc03b3dc23