### PR TITLE
Add milestone template library

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ npm test
 ```
 
 Vitest and React Testing Library power the test suite.
+
+## Milestone Templates
+
+The app now includes a library of reusable milestone templates. Selecting a template when adding a milestone will clone the milestone and its pre-defined tasks. You can also save any existing milestone as a new template. Default templates are seeded from [`scripts/defaultMilestoneTemplates.json`](scripts/defaultMilestoneTemplates.json).

--- a/scripts/defaultMilestoneTemplates.json
+++ b/scripts/defaultMilestoneTemplates.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "default-module-1",
+    "title": "Module 1 – Canvas Setup",
+    "goal": "Prepare Canvas module shell",
+    "tasks": [
+      { "title": "Create module structure", "details": "", "workDays": 1 },
+      { "title": "Upload syllabus", "details": "", "workDays": 1 }
+    ]
+  },
+  {
+    "id": "default-module-2",
+    "title": "Module 2 – Content Draft",
+    "goal": "Draft learning content",
+    "tasks": [
+      { "title": "Outline lesson", "details": "", "workDays": 2 },
+      { "title": "Prepare assessments", "details": "", "workDays": 2 }
+    ]
+  }
+]

--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useEffect } from 'react';
-import { Copy as CopyIcon, Trash2, ChevronDown } from 'lucide-react';
+import { Copy as CopyIcon, Trash2, ChevronDown, Download } from 'lucide-react';
 import TaskCard from './TaskCard.jsx';
 
 export default function MilestoneCard({
@@ -16,6 +16,7 @@ export default function MilestoneCard({
   onAddLink,
   onRemoveLink,
   onUpdateMilestone,
+  onSaveAsTemplate,
 }) {
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState(milestone.title);
@@ -99,6 +100,19 @@ export default function MilestoneCard({
                 aria-label="Duplicate Milestone"
               >
                 <CopyIcon size={16} />
+              </button>
+            )}
+            {onSaveAsTemplate && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSaveAsTemplate(milestone.id);
+                }}
+                className="inline-flex items-center justify-center w-9 h-9 sm:w-11 sm:h-11 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
+                title="Save as Milestone Template"
+                aria-label="Save as Milestone Template"
+              >
+                <Download size={16} />
               </button>
             )}
             {onDeleteMilestone && (


### PR DESCRIPTION
## Summary
- add milestoneTemplates store with local/remote persistence
- allow saving milestones as templates and adding milestones from templates
- seed app with default module templates

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden for @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b2bee930832b96bcfd253f1dfa31