### PR TITLE
feat: add unicode icons to dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -672,7 +672,7 @@ const filteredMilestones = useMemo(() => (milestoneFilter === "all" ? milestones
       <header className="sticky top-0 z-30 backdrop-blur supports-[backdrop-filter]:bg-white/60 bg-white/80 border-b border-black/5">
         <div className="max-w-7xl mx-auto px-4 py-3 flex flex-wrap items-center gap-3">
           {onBack && (
-            <button onClick={onBack} className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm bg-slate-900 text-white border border-slate-900 shadow-sm hover:bg-slate-800"><ArrowLeft size={16}/> Back to Courses</button>
+            <button onClick={onBack} className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm bg-slate-900 text-white border border-slate-900 shadow-sm hover:bg-slate-800"><ArrowLeft size={16}/> Back to 📚︎ Courses</button>
           )}
           <div className={`w-9 h-9 rounded-xl bg-gradient-to-br ${state.course.accent} shadow-sm`} />
           {/* DART banner title */}
@@ -880,8 +880,8 @@ const filteredMilestones = useMemo(() => (milestoneFilter === "all" ? milestones
         {/* Tasks */}
         <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
           <div className="flex flex-wrap items-center justify-between mb-3 gap-2">
-            <h2 className="font-semibold flex items-center gap-2"><ListChecks size={18}/> Tasks</h2>
-            <div className="flex items-center gap-2"><Toggle value={view} onChange={setView} options={[{ id: "list", label: "List" }, { id: "board", label: "Board" }, { id: "calendar", label: "Calendar" }]} /><button onClick={() => addTask(milestoneFilter !== "all" ? milestoneFilter : undefined)} className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-black text-white shadow hover:opacity-90"><Plus size={16}/> Add Task</button></div>
+            <h2 className="font-semibold flex items-center gap-2">☑ Tasks</h2>
+            <div className="flex items-center gap-2"><Toggle value={view} onChange={setView} options={[{ id: "list", label: "☰ List" }, { id: "board", label: "⎘ Board" }, { id: "calendar", label: "📅︎ Calendar" }]} /><button onClick={() => addTask(milestoneFilter !== "all" ? milestoneFilter : undefined)} className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-black text-white shadow hover:opacity-90"><Plus size={16}/> Add Task</button></div>
           </div>
             {view === "list" ? (
               <TaskChecklist
@@ -1383,11 +1383,11 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
                 onClick={onBack}
                 className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm bg-slate-900 text-white border border-slate-900 shadow-sm hover:bg-slate-800"
               >
-                <ArrowLeft size={16} /> Back to Courses
+                <ArrowLeft size={16} /> Back to 📚︎ Courses
               </button>
             )}
             <div className="min-w-0">
-              <h1 className="text-sm sm:text-base font-semibold truncate">User Dashboard</h1>
+              <h1 className="text-sm sm:text-base font-semibold truncate">🏠︎ User Dashboard</h1>
               {user && <div className="text-sm text-black/60 truncate">{user.name}</div>}
             </div>
           </div>
@@ -1396,6 +1396,8 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
             <select value={userId} onChange={(e)=>setUserId(e.target.value)} className="text-sm border rounded px-2 py-1">
               {members.map((m)=> (<option key={m.id} value={m.id}>{m.name} ({m.roleType})</option>))}
             </select>
+            <button className="inline-flex items-center justify-center rounded-xl p-2 bg-white border border-black/10 shadow-sm hover:bg-slate-50" title="Settings" aria-label="Settings">⚙︎</button>
+            <button className="inline-flex items-center justify-center rounded-xl p-2 bg-white border border-black/10 shadow-sm hover:bg-slate-50" title="Help" aria-label="Help">❓︎</button>
             <button
               onClick={handleSave}
               className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
@@ -1417,11 +1419,13 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
           )}
           <div className="mb-4 flex gap-2">
             {[
-              ['deadlines','Deadlines'],
-              ['courses','Courses'],
+              ['deadlines','🏠︎ Home'],
+              ['courses','📚︎ Courses'],
               ['milestones','Milestones'],
-              ['board','Board View'],
-              ['calendar','Calendar View']
+              ['board','⎘ Board View'],
+              ['calendar','📅︎ Calendar View'],
+              ['settings','⚙︎ Settings'],
+              ['help','❓︎ Help']
             ].map(([id,label]) => (
               <button
                 key={id}
@@ -1491,7 +1495,7 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
           )}
 
           {activeTab === 'courses' && (
-            <SectionCard title="My Courses">
+            <SectionCard title="📚︎ My Courses">
               {myCourses.length === 0 ? (
                 <div className="text-sm text-black/60">No courses</div>
               ) : (
@@ -1565,7 +1569,7 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
           )}
 
           {activeTab === 'board' && (
-            <SectionCard title="My Tasks – Board View" actions={<button onClick={handleNewTask} className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"><Plus size={16}/> New Task</button>}>
+            <SectionCard title="☑ My Tasks – Board View" actions={<button onClick={handleNewTask} className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"><Plus size={16}/> New Task</button>}>
               {myTasks.length === 0 ? (
                 <div className="text-sm text-black/60">{taskQuery ? 'No tasks match your search.' : 'No tasks assigned.'}</div>
               ) : (
@@ -1634,7 +1638,7 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
           )}
 
           {activeTab === 'calendar' && (
-            <SectionCard title="My Tasks – Calendar View" actions={<button onClick={handleNewTask} className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"><Plus size={16}/> New Task</button>}>
+            <SectionCard title="☑ My Tasks – Calendar View" actions={<button onClick={handleNewTask} className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"><Plus size={16}/> New Task</button>}>
               {myTasks.length === 0 ? (
                 <div className="text-sm text-black/60">{taskQuery ? 'No tasks match your search.' : 'No tasks assigned.'}</div>
               ) : (
@@ -1661,6 +1665,16 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
                   />
                 </>
               )}
+            </SectionCard>
+          )}
+          {activeTab === 'settings' && (
+            <SectionCard title="⚙︎ Settings">
+              <div className="text-sm text-black/60">Settings coming soon.</div>
+            </SectionCard>
+          )}
+          {activeTab === 'help' && (
+            <SectionCard title="❓︎ Help">
+              <div className="text-sm text-black/60">Help content coming soon.</div>
             </SectionCard>
           )}
 
@@ -1900,7 +1914,7 @@ export function CoursesHub({
             <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-violet-500 via-fuchsia-500 to-rose-500"/>
             <div className="min-w-0">
               <div className="text-sm sm:text-base font-semibold truncate">DART: Design and Development Accountability and Responsibility Tracker</div>
-              <div className="text-sm text-black/60 truncate">Courses Hub</div>
+              <div className="text-sm text-black/60 truncate">📚︎ Courses Hub</div>
             </div>
           </div>
           <div className="flex items-center gap-2">
@@ -1927,7 +1941,7 @@ export function CoursesHub({
         {/* Team member management */}
         <section>
           <div className="flex items-center justify-between mb-2">
-            <h2 className="text-lg font-semibold">Team Members</h2>
+            <h2 className="text-lg font-semibold">👥︎ Team Members</h2>
             <div className="flex items-center gap-2">
               <button
                 onClick={addPerson}
@@ -2077,7 +2091,7 @@ export function CoursesHub({
         </section>
 
         <section>
-          <h2 className="text-lg font-semibold mb-2">All Courses</h2>
+          <h2 className="text-lg font-semibold mb-2">📚︎ All Courses</h2>
           {courses.length === 0 ? (
             <div className="rounded-2xl border border-black/10 bg-white p-6 text-center">
               <div className="text-lg font-semibold mb-2">No courses yet</div>

--- a/src/components/TeamMembersSection.jsx
+++ b/src/components/TeamMembersSection.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Users, UserPlus, Trash2 } from "lucide-react";
+import { UserPlus, Trash2 } from "lucide-react";
 import { rolePalette } from "../utils.js";
 import Avatar from "./Avatar.jsx";
 
@@ -77,9 +77,7 @@ export default function TeamMembersSection({
   return (
     <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
       <div className="flex items-center justify-between mb-2">
-        <h2 className="font-semibold flex items-center gap-2">
-          <Users size={18} /> Team Members
-        </h2>
+        <h2 className="font-semibold flex items-center gap-2">👥︎ Team Members</h2>
         <div className="flex items-center gap-2">
           <select
             value=""


### PR DESCRIPTION
## Summary
- add text-based icons for list, board, calendar views
- decorate dashboard sections and navigation with emoji icons
- introduce placeholder settings and help tabs

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden fetching @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c5981848832b963427648c38d46c