### PR TITLE
Replace Unicode icons with lucide-react components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import { applyLinkPatch } from "./linkUtils.js";
 import { SoundContext } from "./sound-context.js";
 import pkg from "../package.json";
 import defaultMilestoneTemplates from "../scripts/defaultMilestoneTemplates.json";
+import { X } from "lucide-react";
 import {
   uid,
   todayStr,
@@ -2053,12 +2054,11 @@ export function CoursesHub({
                   >
                     {h}
                     <button
-                      className="text-rose-500 hover:text-rose-700"
                       onClick={() => removeHoliday(h)}
                       title="Remove holiday"
                       aria-label="Remove holiday"
                     >
-                      ×
+                      <X className="icon text-rose-500 hover:text-rose-700" />
                     </button>
                   </span>
                 ))}

--- a/src/components/LinksEditor.jsx
+++ b/src/components/LinksEditor.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link2, X } from "lucide-react";
 
 export function LinksEditor({ links = [], onAdd, onRemove }) {
   const [val, setVal] = useState("");
@@ -22,7 +23,7 @@ export function LinksEditor({ links = [], onAdd, onRemove }) {
             rel="noreferrer"
             className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-sm border border-black/10 bg-white hover:bg-slate-50"
           >
-            🔗
+            <Link2 className="icon" />
             {(() => {
               try {
                 return new URL(l).hostname;
@@ -32,14 +33,13 @@ export function LinksEditor({ links = [], onAdd, onRemove }) {
             })()}
             <button
               type="button"
-              className="ml-1 text-slate-400 hover:text-rose-600"
               onClick={(e) => {
                 e.preventDefault();
                 onRemove?.(i);
               }}
               aria-label="Remove link"
             >
-              ×
+              <X className="icon ml-1 text-slate-400 hover:text-rose-600" />
             </button>
           </a>
         ))}
@@ -76,7 +76,7 @@ export function LinkChips({ links = [], onRemove }) {
           rel="noreferrer"
           className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] border border-black/10 bg-white hover:bg-slate-50"
         >
-          🔗
+          <Link2 className="icon" />
           {(() => {
             try {
               return new URL(l).hostname;
@@ -86,14 +86,13 @@ export function LinkChips({ links = [], onRemove }) {
           })()}
           <button
             type="button"
-            className="ml-1 text-slate-400 hover:text-rose-600"
             onClick={(e) => {
               e.preventDefault();
               onRemove?.(i);
             }}
             aria-label="Remove link"
           >
-            ×
+            <X className="icon ml-1 text-slate-400 hover:text-rose-600" />
           </button>
         </a>
       ))}

--- a/src/components/TaskModal.jsx
+++ b/src/components/TaskModal.jsx
@@ -5,6 +5,7 @@ import DocumentInput from "./DocumentInput.jsx";
 import { LinkChips } from "./LinksEditor.jsx";
 import DepPicker from "./DepPicker.jsx";
 import DuePill from "./DuePill.jsx";
+import { X } from "lucide-react";
 
 function statusBg(status) {
   if (status === "done") return "bg-emerald-50";
@@ -80,8 +81,8 @@ export default function TaskModal({ task, courseId, courses, onChangeCourse, tas
               />
             </div>
           </div>
-          <button onClick={handleClose} className="text-slate-500 hover:text-black" aria-label="Close">
-            ×
+          <button onClick={handleClose} aria-label="Close">
+            <X className="icon text-slate-500 hover:text-black" />
           </button>
         </div>
         <div className="mt-3 flex flex-wrap items-center gap-2 text-sm">


### PR DESCRIPTION
## Summary
- replace Unicode symbols with `lucide-react` icon components across LinksEditor, TaskModal, and App
- add `lucide-react` imports and align class names with icon elements

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7eafd8410832b8bc05c20a2697834