### PR TITLE
Use icons for milestone actions

### DIFF
--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import TaskCard from './TaskCard.jsx';
+import { Copy, Save, Trash } from 'lucide-react';
 
 export default function MilestoneCard({
   milestone,
@@ -98,7 +99,7 @@ export default function MilestoneCard({
                 title="Duplicate Milestone"
                 aria-label="Duplicate Milestone"
               >
-                Copy
+                <Copy className="icon" />
               </button>
             )}
             {onSaveAsTemplate && (
@@ -111,7 +112,7 @@ export default function MilestoneCard({
                 title="Save as Milestone Template"
                 aria-label="Save as Milestone Template"
               >
-                Save
+                <Save className="icon" />
               </button>
             )}
             {onDeleteMilestone && (
@@ -124,7 +125,7 @@ export default function MilestoneCard({
                 title="Remove Milestone"
                 aria-label="Remove Milestone"
               >
-                Delete
+                <Trash className="icon" />
               </button>
             )}
           </div>


### PR DESCRIPTION
## Summary
- switch milestone action buttons to lucide-react Copy, Save, and Trash icons
- apply shared `.icon` styling and retain accessible labels

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ef9709e8832ba1ba83472e7977d2