### PR TITLE
Use icons in button controls

### DIFF
--- a/src/components/AddHoliday.jsx
+++ b/src/components/AddHoliday.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Plus } from "lucide-react";
 
 export default function AddHoliday({ onAdd }) {
   const [d, setD] = useState("");
@@ -19,8 +20,9 @@ export default function AddHoliday({ onAdd }) {
           }
         }}
         className="px-2 py-1 text-sm rounded border border-black/10 bg-white hover:bg-slate-50"
+        aria-label="Add holiday"
       >
-        Add
+        <Plus className="icon" />
       </button>
     </div>
   );

--- a/src/components/DocumentInput.jsx
+++ b/src/components/DocumentInput.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Plus } from "lucide-react";
 
 export default function DocumentInput({ onAdd }) {
   const [val, setVal] = useState("");
@@ -30,8 +31,9 @@ export default function DocumentInput({ onAdd }) {
       <button
         onClick={add}
         className="px-2 py-1 rounded border border-black/10 bg-white hover:bg-slate-50"
+        aria-label="Add document"
       >
-        Add
+        <Plus className="icon" />
       </button>
     </div>
   );

--- a/src/components/LinkReminderModal.jsx
+++ b/src/components/LinkReminderModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Check, X } from "lucide-react";
 
 export default function LinkReminderModal({ onOkay, onNoLink }) {
   return (
@@ -9,14 +10,16 @@ export default function LinkReminderModal({ onOkay, onNoLink }) {
           <button
             onClick={onOkay}
             className="px-4 py-2 rounded border border-slate-300 bg-white hover:bg-slate-50"
+            aria-label="Okay"
           >
-            Okay
+            <Check className="icon" />
           </button>
           <button
             onClick={onNoLink}
             className="px-4 py-2 rounded border border-slate-300 bg-white hover:bg-slate-50"
+            aria-label="No link"
           >
-            No link
+            <X className="icon" />
           </button>
         </div>
       </div>

--- a/src/components/LinksEditor.jsx
+++ b/src/components/LinksEditor.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Link2, X } from "lucide-react";
+import { Link2, X, Plus } from "lucide-react";
 
 export function LinksEditor({ links = [], onAdd, onRemove }) {
   const [val, setVal] = useState("");
@@ -57,8 +57,9 @@ export function LinksEditor({ links = [], onAdd, onRemove }) {
         <button
           onClick={add}
           className="px-2 py-1 text-sm rounded border border-black/10 bg-white hover:bg-slate-50"
+          aria-label="Add link"
         >
-          Add
+          <Plus className="icon" />
         </button>
       </div>
     </div>

--- a/src/components/TeamMembersSection.jsx
+++ b/src/components/TeamMembersSection.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Plus, X } from "lucide-react";
 import { rolePalette } from "../utils.js";
 import Avatar from "./Avatar.jsx";
 
@@ -53,7 +54,7 @@ function TeamMemberCard({
             aria-label="Remove member"
             onClick={() => onDelete(member.id)}
           >
-            Remove
+            <X className="icon" />
           </button>
         </div>
       </div>
@@ -100,8 +101,9 @@ export default function TeamMembersSection({
           <button
             onClick={onAddMember}
             className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
+            aria-label="Add member"
           >
-            Add Member
+            <Plus className="icon" />
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replace text buttons with `lucide-react` icons in components like DocumentInput, AddHoliday, LinkReminderModal, LinksEditor, and TeamMembersSection
- Ensure icons use the shared `.icon` class and preserve `aria-label` attributes for accessibility

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f0043410832b80b5d4cec55d6c76