### PR TITLE
Remove unused help and settings tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1102,7 +1102,8 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
   const [courseQuery, setCourseQuery] = useState('');
   const [activeTab, setActiveTab] = useState(() => {
     const stored = localStorage.getItem('userTab');
-    return stored && stored !== 'tasks' ? stored : 'deadlines';
+    const validTabs = new Set(['deadlines','courses','milestones','board','calendar']);
+    return stored && validTabs.has(stored) ? stored : 'deadlines';
   });
 
   const recomputeDue = (t, patch = {}, schedule) => {
@@ -1401,9 +1402,7 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
               ['courses','📚︎ Courses'],
               ['milestones','Milestones'],
               ['board','⎘ Board View'],
-              ['calendar','📅︎ Calendar View'],
-              ['settings','⚙︎ Settings'],
-              ['help','❓︎ Help']
+              ['calendar','📅︎ Calendar View']
             ].map(([id,label]) => (
               <button
                 key={id}
@@ -1645,17 +1644,6 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
               )}
             </SectionCard>
           )}
-          {activeTab === 'settings' && (
-            <SectionCard title="⚙︎ Settings">
-              <div className="text-sm text-black/60">Settings coming soon.</div>
-            </SectionCard>
-          )}
-          {activeTab === 'help' && (
-            <SectionCard title="❓︎ Help">
-              <div className="text-sm text-black/60">Help content coming soon.</div>
-            </SectionCard>
-          )}
-
         </div>
         {editing && (() => {
           const c = courses.find((x) => x.course.id === editing.courseId);


### PR DESCRIPTION
## Summary
- Strip out Help and Settings tabs from dashboard navigation
- Validate stored tab against remaining valid views

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f0a845a4832ba8bf2efff32751e3