### PR TITLE
Remove floating add task button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -900,16 +900,6 @@ const filteredMilestones = useMemo(() => (milestoneFilter === "all" ? milestones
       )}
       </main>
 
-      {isMobile && (
-        <button
-          onClick={() => addTask(milestoneFilter !== "all" ? milestoneFilter : undefined)}
-          className="fixed bottom-6 right-6 z-50 inline-flex items-center justify-center w-14 h-14 rounded-full bg-black text-white shadow-lg sm:hidden"
-          aria-label="Add task"
-        >
-          +
-        </button>
-      )}
-
       <footer className="max-w-7xl mx-auto px-4 pb-10 text-sm text-black/50">Tip: ⌘/Ctrl + Enter to commit multiline edits. Data auto-saves to your browser.</footer>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove mobile-only floating "+" task button from dashboard

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: E403 Forbidden for @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f1523ca8832b91c4c9c966321ba3