### PR TITLE
Remove floating add task button and fix course title overflow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -684,9 +684,9 @@ const filteredMilestones = useMemo(() => (milestoneFilter === "all" ? milestones
         </div>
         {/* Secondary row: course title and template pill */}
         <div className="max-w-7xl mx-auto px-4 pb-3 -mt-2">
-          <div className="flex items-center gap-2">
-            <h1 className="text-base sm:text-lg font-semibold leading-tight"><InlineText value={state.course.name} onChange={(v)=>setState((s)=>({ ...s, course: { ...s.course, name: v } }))} /></h1>
-            {isTemplateLabel && <span className="text-sm px-2 py-0.5 rounded-full bg-violet-100 text-violet-800 border border-violet-200">Course Template</span>}
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-base sm:text-lg font-semibold leading-tight flex-1 min-w-0"><InlineText className="break-words" value={state.course.name} onChange={(v)=>setState((s)=>({ ...s, course: { ...s.course, name: v } }))} /></h1>
+            {isTemplateLabel && <span className="text-sm px-2 py-0.5 rounded-full bg-violet-100 text-violet-800 border border-violet-200 whitespace-nowrap">Course Template</span>}
           </div>
           <p className="text-sm text-black/60"><InlineText value={state.course.description} onChange={(v)=>setState((s)=>({ ...s, course: { ...s.course, description: v } }))} /></p>
           {/* Course-wide LDs & SMEs */}
@@ -899,16 +899,6 @@ const filteredMilestones = useMemo(() => (milestoneFilter === "all" ? milestones
         />
       )}
       </main>
-
-      {isMobile && (
-        <button
-          onClick={() => addTask(milestoneFilter !== "all" ? milestoneFilter : undefined)}
-          className="fixed bottom-6 right-6 z-50 inline-flex items-center justify-center w-14 h-14 rounded-full bg-black text-white shadow-lg sm:hidden"
-          aria-label="Add task"
-        >
-          +
-        </button>
-      )}
 
       <footer className="max-w-7xl mx-auto px-4 pb-10 text-sm text-black/50">Tip: ⌘/Ctrl + Enter to commit multiline edits. Data auto-saves to your browser.</footer>
     </div>


### PR DESCRIPTION
## Summary
- remove mobile-only floating "+" task button from dashboard
- prevent course title text from overflowing on mobile by allowing wrapping and constraining width

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden for @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f1523ca8832b91c4c9c966321ba3