### PR TITLE
Use SVG icons and standardize button sizing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,7 +22,7 @@ import { applyLinkPatch } from "./linkUtils.js";
 import { SoundContext } from "./sound-context.js";
 import pkg from "../package.json";
 import defaultMilestoneTemplates from "../scripts/defaultMilestoneTemplates.json";
-import { X } from "lucide-react";
+import { X, Plus, Minus, Copy, Trash2, StickyNote } from "lucide-react";
 import {
   uid,
   todayStr,
@@ -1031,21 +1031,21 @@ export function BoardView({ tasks, team, milestones, onUpdate, onDelete, onDragS
                   >
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0 flex-1"><div className="text-[15px] sm:text-[14px] font-semibold leading-tight truncate"><InlineText value={t.title} onChange={(v)=>onUpdate(t.id,{ title:v })} /></div></div>
-                    <div className="flex items-center gap-1 flex-shrink-0"><button onClick={()=>toggleCollapse(t.id)} className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200" title={collapsed?'Expand':'Collapse'} aria-label={collapsed?'Expand':'Collapse'}>{collapsed ? '+' : '-'}</button><button onClick={()=>onDuplicate(t.id)} className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200" title="Duplicate" aria-label="Duplicate">⧉</button><button onClick={()=>onDelete(t.id)} className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200" title="Delete" aria-label="Delete">🗑️</button></div>
+                    <div className="flex items-center gap-1 flex-shrink-0"><button onClick={()=>toggleCollapse(t.id)} className="inline-flex items-center justify-center w-6 h-6 sm:w-8 sm:h-8 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200" title={collapsed?'Expand':'Collapse'} aria-label={collapsed?'Expand':'Collapse'}>{collapsed ? <Plus className="w-4 h-4" /> : <Minus className="w-4 h-4" />}</button><button onClick={()=>onDuplicate(t.id)} className="inline-flex items-center justify-center w-6 h-6 sm:w-8 sm:h-8 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200" title="Duplicate" aria-label="Duplicate"><Copy className="w-4 h-4" /></button><button onClick={()=>onDelete(t.id)} className="inline-flex items-center justify-center w-6 h-6 sm:w-8 sm:h-8 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200" title="Delete" aria-label="Delete"><Trash2 className="w-4 h-4" /></button></div>
                   </div>
                   {collapsed ? (
                     <>
                       <div className="mt-1">{renderStatusControl(t)}</div>
                       <div className="text-sm text-black/60 mt-1 truncate"><InlineText value={t.details} onChange={(v)=>onUpdate(t.id,{ details:v })} placeholder="Details…" /></div>
-                      {t.note && <div className="text-sm text-slate-600 mt-1 truncate">📝 {t.note}</div>}
-                      <div className="mt-2 flex items-center justify-between text-sm"><div className="flex items-center gap-2 min-w-0">{a ? <Avatar name={a.name} roleType={a.roleType} avatar={a.avatar} /> : <span className="text-black/40">—</span>}<span className="truncate">{a ? `${a.name} (${a.roleType})` : 'Unassigned'}</span></div><div className="flex items-center gap-2"><DuePill date={t.dueDate} status={t.status} />{t.status === "done" && <span className="text-slate-500">Completed: {t.completedDate || "—"}</span>}</div></div>
+                      {t.note && <div className="text-sm text-slate-600 mt-1 flex items-center gap-1 truncate"><StickyNote className="w-4 h-4 flex-shrink-0" />{t.note}</div>}
+                      <div className="mt-2 flex items-center justify-between text-sm"><div className="flex items-center gap-2 min-w-0">{a ? <Avatar name={a.name} roleType={a.roleType} avatar={a.avatar} /> : <span className="text-black/40 text-sm">—</span>}<span className="truncate">{a ? `${a.name} (${a.roleType})` : 'Unassigned'}</span></div><div className="flex items-center gap-2"><DuePill date={t.dueDate} status={t.status} />{t.status === "done" && <span className="text-slate-500">Completed: {t.completedDate || "—"}</span>}</div></div>
                     </>
                   ) : (
                     <>
                       <div className="mt-1">{renderStatusControl(t)}</div>
                       <div className="mt-2 flex flex-wrap items-center gap-2 text-sm">
                         <select value={t.milestoneId} onChange={(e)=>onUpdate(t.id,{ milestoneId:e.target.value })} className="border rounded px-1.5 py-1">{milestones.map((m)=>(<option key={m.id} value={m.id}>{m.title}</option>))}</select>
-                        <div className="flex items-center gap-1">{a ? <Avatar name={a.name} roleType={a.roleType} avatar={a.avatar} /> : <span className="text-black/40">—</span>}<select value={t.assigneeId || ""} onChange={(e)=>onUpdate(t.id,{ assigneeId:e.target.value || null })} className="border rounded px-1.5 py-1"><option value="">Unassigned</option>{taskAssignableMembers.map((m)=>(<option key={m.id} value={m.id}>{m.name} ({m.roleType})</option>))}</select></div>
+                        <div className="flex items-center gap-1">{a ? <Avatar name={a.name} roleType={a.roleType} avatar={a.avatar} /> : <span className="text-black/40 text-sm">—</span>}<select value={t.assigneeId || ""} onChange={(e)=>onUpdate(t.id,{ assigneeId:e.target.value || null })} className="border rounded px-1.5 py-1"><option value="">Unassigned</option>{taskAssignableMembers.map((m)=>(<option key={m.id} value={m.id}>{m.name} ({m.roleType})</option>))}</select></div>
                         <div className="flex items-center gap-2"><span>Start</span><input type="date" value={t.startDate || ""} onChange={(e)=>{ const patch = { startDate: e.target.value }; if (t.status === 'todo') patch.status = 'inprogress'; onUpdate(t.id, patch); }} className="border rounded px-1.5 py-1" /></div>
                         <div className="flex items-center gap-2"><span># of Workdays</span><input type="number" min={0} value={t.workDays ?? 0} onChange={(e)=>onUpdate(t.id,{ workDays:Number(e.target.value) })} className="w-20 border rounded px-1.5 py-1" /></div>
                         <div className="basis-full w-full"><DocumentInput onAdd={(url)=>onAddLink(t.id,url)} />{t.links && t.links.length>0 && (<LinkChips links={t.links} onRemove={(i)=>onRemoveLink(t.id,i)} />)}</div>

--- a/src/TaskCard.jsx
+++ b/src/TaskCard.jsx
@@ -9,6 +9,7 @@ import DocumentInput from './components/DocumentInput.jsx';
 import DepPicker from './components/DepPicker.jsx';
 import LinkReminderModal from './components/LinkReminderModal.jsx';
 import { SoundContext } from './sound-context.js';
+import { Plus, Minus, Copy, Trash2, Pencil, StickyNote } from 'lucide-react';
 
 export default function TaskCard({ task: t, team = [], milestones = [], tasks = [], onUpdate, onDelete, onDuplicate, onAddLink, onRemoveLink, dragHandlers = {} }) {
   const [collapsed, setCollapsed] = useState(true);
@@ -92,7 +93,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
             className="inline-flex items-center justify-center w-6 h-6 sm:w-8 sm:h-8 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
             title={collapsed ? 'Expand' : 'Collapse'}
           >
-            {collapsed ? '+' : '-'}
+            {collapsed ? <Plus className="w-4 h-4" /> : <Minus className="w-4 h-4" />}
           </button>
           {onDuplicate && (
             <button
@@ -101,7 +102,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
               title="Duplicate"
               aria-label="Duplicate"
             >
-              ⧉
+              <Copy className="w-4 h-4" />
             </button>
           )}
           {onDelete && (
@@ -111,7 +112,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
               title="Delete"
               aria-label="Delete"
             >
-              🗑️
+              <Trash2 className="w-4 h-4" />
             </button>
           )}
         </div>
@@ -164,13 +165,17 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
           <div className="text-sm text-black/60 mt-1 truncate">
             <InlineText value={t.details} onChange={(v) => update(t.id, { details: v })} placeholder="Details…" />
           </div>
-          {t.note && <div className="text-sm text-slate-600 mt-1 truncate">📝 {t.note}</div>}
+          {t.note && (
+            <div className="text-sm text-slate-600 mt-1 flex items-center gap-1 truncate">
+              <StickyNote className="w-4 h-4 flex-shrink-0" /> {t.note}
+            </div>
+          )}
             <div className="mt-2 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 text-sm">
               <div className="flex items-start gap-2 min-w-0">
                 {a ? (
                   <Avatar name={a.name} roleType={a.roleType} avatar={a.avatar} />
                 ) : (
-                  <span className="text-black/40">—</span>
+                  <span className="text-black/40 text-sm">—</span>
                 )}
                 <div className="flex flex-col min-w-0">
                   <select
@@ -249,7 +254,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
             {a ? (
               <Avatar name={a.name} roleType={a.roleType} avatar={a.avatar} />
             ) : (
-              <span className="text-black/40">—</span>
+              <span className="text-black/40 text-sm">—</span>
             )}
             <div className="flex flex-col min-w-0">
               <select
@@ -290,7 +295,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                     className="text-slate-400 hover:text-slate-600"
                     aria-label="Edit Milestone"
                   >
-                    ✎
+                    <Pencil className="w-4 h-4" />
                   </button>
                 </div>
               )}


### PR DESCRIPTION
## Summary
- replace Unicode symbols in task controls with lucide-react SVG icons
- normalize icon button dimensions for consistent desktop/mobile layout
- adjust placeholder dash sizing and swap sticky note/pencil icons for lucide equivalents

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f9c53000832bb929907c428bf0a7