### PR TITLE
Expand lucide-react icon imports

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,19 @@ import {
   createTemplateFromMilestone,
   removeTemplate as removeMilestoneTemplateStore,
 } from "./milestoneTemplatesStore.js";
-import { X, Plus, Minus, Copy, Trash2, StickyNote } from "lucide-react";
+import {
+  X,
+  Plus,
+  Minus,
+  Copy,
+  Trash2,
+  StickyNote,
+  Home,
+  BookOpen,
+  Calendar,
+  Kanban,
+  CheckSquare,
+} from "lucide-react";
 import {
   uid,
   todayStr,


### PR DESCRIPTION
## Summary
- consolidate lucide-react imports and include Home, BookOpen, Calendar, Kanban, CheckSquare icons
- keep utilities import intact after lucide-react block

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden fetching @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68c805d22394832baaa0b4013bf83610