### PR TITLE
Improve mobile layouts and milestone controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -738,7 +738,7 @@ const filteredMilestones = useMemo(() => (milestoneFilter === "all" ? milestones
                   <select
                     value={milestoneFilter}
                     onChange={e => setMilestoneFilter(e.target.value)}
-                    className="text-sm outline-none bg-transparent"
+                    className="text-sm outline-none bg-transparent w-full sm:w-auto"
                   >
                     <option value="all">All milestones</option>
                     {milestones.map(m => (
@@ -1374,8 +1374,6 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
             <select value={userId} onChange={(e)=>setUserId(e.target.value)} className="text-sm border rounded px-2 py-1">
               {members.map((m)=> (<option key={m.id} value={m.id}>{m.name} ({m.roleType})</option>))}
             </select>
-            <button className="inline-flex items-center justify-center rounded-xl p-2 bg-white border border-black/10 shadow-sm hover:bg-slate-50" title="Settings" aria-label="Settings">⚙︎</button>
-            <button className="inline-flex items-center justify-center rounded-xl p-2 bg-white border border-black/10 shadow-sm hover:bg-slate-50" title="Help" aria-label="Help">❓︎</button>
             <button
               onClick={handleSave}
               className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
@@ -2077,12 +2075,12 @@ export function CoursesHub({
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' || e.key === ' ') open(c.id);
                     }}
-                    className="group rounded-2xl border border-black/10 bg-white p-4 shadow-sm cursor-pointer hover:ring-2 hover:ring-slate-300 focus:outline-none focus:ring-2 focus:ring-slate-400"
+                    className="group w-full rounded-2xl border border-black/10 bg-white p-4 shadow-sm cursor-pointer hover:ring-2 hover:ring-slate-300 focus:outline-none focus:ring-2 focus:ring-slate-400"
                   >
                     <div className="flex items-start justify-between gap-2">
                       <div className="min-w-0"><div className="font-semibold truncate">{c.course.name}</div><div className="text-sm text-black/60 truncate">{c.course.description}</div></div>
                     </div>
-                    <div className="flex items-center gap-4 mt-3">
+                    <div className="flex flex-col sm:flex-row sm:items-center gap-4 mt-3">
                       <Ring className="w-14 h-14 xs:w-16 xs:h-16" stroke={10} progress={t.pct} color="#10b981">
                         <div className="text-center">
                           <div className="text-sm font-semibold">{t.pct}%</div>

--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -95,7 +95,7 @@ export default function MilestoneCard({
                   e.stopPropagation();
                   onDuplicateMilestone(milestone.id);
                 }}
-                className="inline-flex items-center justify-center w-9 h-9 sm:w-11 sm:h-11 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
+                className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
                 title="Duplicate Milestone"
                 aria-label="Duplicate Milestone"
               >
@@ -108,7 +108,7 @@ export default function MilestoneCard({
                   e.stopPropagation();
                   onSaveAsTemplate(milestone.id);
                 }}
-                className="inline-flex items-center justify-center w-9 h-9 sm:w-11 sm:h-11 rounded-full border border-black/10 bg-green-50 text-green-600 hover:bg-green-100"
+                className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-black/10 bg-green-50 text-green-600 hover:bg-green-100"
                 title="Save as Milestone Template"
                 aria-label="Save as Milestone Template"
               >
@@ -121,7 +121,7 @@ export default function MilestoneCard({
                   e.stopPropagation();
                   onDeleteMilestone(milestone.id);
                 }}
-                className="inline-flex items-center justify-center w-9 h-9 sm:w-11 sm:h-11 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
+                className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
                 title="Remove Milestone"
                 aria-label="Remove Milestone"
               >

--- a/src/TaskCard.jsx
+++ b/src/TaskCard.jsx
@@ -63,6 +63,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
     if (status === 'inprogress') return 'bg-emerald-100 text-emerald-900 border-emerald-300';
     return 'bg-slate-100 text-slate-700 border-slate-300';
   };
+  const statusPillBase = 'min-w-[8rem] px-2 pr-6 py-1 rounded-full border font-semibold text-sm';
   const handleStatusChange = (value) => {
     if (value === 'done' && (!t.links || t.links.length === 0)) {
       setCollapsed(false);
@@ -130,7 +131,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                     setStatusOpen(false);
                   }}
                   onBlur={() => setStatusOpen(false)}
-                  className={`px-2 py-1 rounded-full border font-semibold text-sm ${statusPillClass(t.status)}`}
+                  className={`${statusPillBase} ${statusPillClass(t.status)}`}
                   autoFocus
                 >
                   <option value="todo">To Do</option>
@@ -144,7 +145,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                   aria-expanded={statusOpen}
                   aria-label={`Status: ${statusLabel[t.status]}`}
                   onClick={() => setStatusOpen((v) => !v)}
-                  className={`px-2 py-1 rounded-full border font-semibold text-sm ${statusPillClass(t.status)}`}
+                  className={`${statusPillBase} ${statusPillClass(t.status)}`}
                 >
                   {statusLabel[t.status]}
                 </button>
@@ -154,7 +155,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                 aria-label="Status"
                 value={t.status}
                 onChange={(e) => handleStatusChange(e.target.value)}
-                className={`px-2 py-1 rounded-full border font-semibold text-sm ${statusPillClass(t.status)}`}
+                className={`${statusPillBase} ${statusPillClass(t.status)}`}
               >
                 <option value="todo">To Do</option>
                 <option value="inprogress">In Progress</option>
@@ -217,7 +218,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                     setStatusOpen(false);
                   }}
                   onBlur={() => setStatusOpen(false)}
-                  className={`px-2 py-1 rounded-full border font-semibold text-sm ${statusPillClass(t.status)}`}
+                  className={`${statusPillBase} ${statusPillClass(t.status)}`}
                   autoFocus
                 >
                   <option value="todo">To Do</option>
@@ -231,7 +232,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                   aria-expanded={statusOpen}
                   aria-label={`Status: ${statusLabel[t.status]}`}
                   onClick={() => setStatusOpen((v) => !v)}
-                  className={`px-2 py-1 rounded-full border font-semibold text-sm ${statusPillClass(t.status)}`}
+                  className={`${statusPillBase} ${statusPillClass(t.status)}`}
                 >
                   {statusLabel[t.status]}
                 </button>
@@ -241,7 +242,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                 aria-label="Status"
                 value={t.status}
                 onChange={(e) => handleStatusChange(e.target.value)}
-                className={`px-2 py-1 rounded-full border font-semibold text-sm ${statusPillClass(t.status)}`}
+                className={`${statusPillBase} ${statusPillClass(t.status)}`}
               >
                 <option value="todo">To Do</option>
                 <option value="inprogress">In Progress</option>
@@ -311,7 +312,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                   if (t.status === 'todo') patch.status = 'inprogress';
                   update(t.id, patch);
                 }}
-                className="border rounded px-1.5 py-1"
+                className="w-20 border rounded px-1.5 py-1"
               />
             </div>
             <div className="flex items-center gap-2">

--- a/src/components/DocumentInput.jsx
+++ b/src/components/DocumentInput.jsx
@@ -26,7 +26,7 @@ export default function DocumentInput({ onAdd }) {
           if (e.key === "Enter") add();
         }}
         placeholder="Paste link and press Enter"
-        className="flex-1"
+        className="w-48"
       />
       <button
         onClick={add}


### PR DESCRIPTION
## Summary
- Shrink milestone action icons for a cleaner card layout
- Align start date with work days, lengthen status pill, and reduce document link input width
- Remove dashboard settings/help buttons and make milestone filters and course cards responsive on small screens

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c8088f096c832bb1f376257e47a4ad