### PR TITLE
Replace unicode arrows with lucide icons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,6 +42,8 @@ import {
   Calendar,
   Kanban,
   CheckSquare,
+  ChevronDown,
+  ChevronUp,
 } from "lucide-react";
 import {
   uid,
@@ -798,7 +800,11 @@ const filteredMilestones = useMemo(() => (milestoneFilter === "all" ? milestones
                   aria-expanded={!milestonesCollapsed}
                   className="inline-flex items-center justify-center w-9 h-9 sm:w-11 sm:h-11 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
                 >
-                  {milestonesCollapsed ? '▼' : '▲'}
+                  {milestonesCollapsed ? (
+                    <ChevronDown className="icon" />
+                  ) : (
+                    <ChevronUp className="icon" />
+                  )}
                 </button>
             </div>
           </div>
@@ -1508,7 +1514,7 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
                     <details key={c.course.id} className="group rounded-xl border border-black/10 bg-white">
                       <summary className="cursor-pointer select-none p-4 flex items-center justify-between gap-2 list-none [&::-webkit-details-marker]:hidden">
                         <div className="flex items-center gap-2">
-                          <span className="w-4 h-4 transition-transform group-open:rotate-180">▼</span>
+                          <ChevronDown className="w-4 h-4 transition-transform group-open:rotate-180" />
                           <div className="font-medium">{c.course.name}</div>
                         </div>
                       </summary>

--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import TaskCard from './TaskCard.jsx';
-import { Copy, Save, Trash } from 'lucide-react';
+import { Copy, Save, Trash, ChevronDown } from 'lucide-react';
 
 export default function MilestoneCard({
   milestone,
@@ -46,7 +46,7 @@ export default function MilestoneCard({
       <details className="group rounded-xl border border-black/10 bg-white">
         <summary className="cursor-pointer select-none p-4 flex flex-wrap items-center justify-between gap-2 list-none [&::-webkit-details-marker]:hidden">
         <div className="flex items-center gap-2 flex-1">
-          <span className="w-4 h-4 transition-transform group-open:rotate-180">▼</span>
+          <ChevronDown className="w-4 h-4 transition-transform group-open:rotate-180" />
           <div className="flex-1">
             {onUpdateMilestone ? (
               editingTitle ? (


### PR DESCRIPTION
## Summary
- Replace hard-coded Unicode arrows with lucide-react `<ChevronDown>` and `<ChevronUp>` icons.
- Update Milestone and My Milestones sections to use icon components for consistent styling.

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fforms)*

------
https://chatgpt.com/codex/tasks/task_e_68c80faa331c832ba215f0a7da234f5d