### PR TITLE
feat: allow cards to span full width on mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -723,7 +723,7 @@ const filteredMilestones = useMemo(() => (milestoneFilter === "all" ? milestones
           courseSMEIds={state.course.courseSMEIds}
         />
         {/* Milestones */}
-          <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm text-sm sm:text-[14px]">
+          <section className="-mx-4 sm:mx-0 bg-white shadow-sm sm:rounded-2xl sm:border border-black/10 p-0 sm:p-4 text-sm sm:text-[14px]">
             <div
               className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-2 px-1 cursor-pointer"
               onClick={() => setMilestonesCollapsed(v => !v)}
@@ -871,7 +871,7 @@ const filteredMilestones = useMemo(() => (milestoneFilter === "all" ? milestones
         </section>
 
         {/* Tasks */}
-        <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
+        <section className="-mx-4 sm:mx-0 bg-white shadow-sm sm:rounded-2xl sm:border border-black/10 p-0 sm:p-4">
           <div className="flex flex-wrap items-center justify-between mb-3 gap-2">
             <h2 className="font-semibold flex items-center gap-2">☑ Tasks</h2>
             <div className="flex items-center gap-2"><Toggle value={view} onChange={setView} options={[{ id: "list", label: "☰ List" }, { id: "board", label: "⎘ Board" }, { id: "calendar", label: "📅︎ Calendar" }]} /><button onClick={() => addTask(milestoneFilter !== "all" ? milestoneFilter : undefined)} className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-black text-white shadow hover:opacity-90">Add Task</button></div>

--- a/src/components/SectionCard.jsx
+++ b/src/components/SectionCard.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 
 export default function SectionCard({ title, actions, children, className = '' }) {
   return (
-    <section className={`rounded-xl border bg-white p-4 shadow-sm ${className}`}>
-      <div className="flex items-center justify-between mb-2">
+    <section
+      className={`-mx-4 sm:mx-0 bg-white shadow-sm sm:rounded-xl sm:border border-black/10 ${className}`}
+    >
+      <div className="px-4 py-4 flex items-center justify-between mb-2">
         <h2 className="text-lg font-semibold">{title}</h2>
         {actions}
       </div>
-      {children}
+      <div className="pb-4 sm:px-4">{children}</div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Let section cards stretch edge-to-edge on small screens
- Expand milestone and task sections to use full width on mobile

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden retrieving @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68c81d3e8674832b94f8eee5734c4ebc