### PR TITLE
fix: responsive course card and icon actions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2067,7 +2067,7 @@ export function CoursesHub({
               <button onClick={onAddCourse} className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm bg-black text-white shadow">Add Course</button>
             </div>
           ) : (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="grid w-full gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {courses.map((c) => {
                 const t = computeTotals(c);
                 return (
@@ -2095,10 +2095,28 @@ export function CoursesHub({
                       </Ring>
                       <div className="text-sm space-y-1"><div>In progress: <b>{t.inprog}</b></div><div>To do: <b>{t.todo}</b></div><div>Next due: <b>{t.nextDue || '—'}</b></div></div>
                     </div>
-                    <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
-                      <button onClick={(e)=>{ e.stopPropagation(); open(c.id); }} className="w-full sm:w-auto inline-flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-sm bg-slate-900 text-white shadow">Open</button>
-                      <button onClick={(e)=>{ e.stopPropagation(); duplicateCourse(c.id); }} className="w-full sm:w-auto inline-flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50">Duplicate</button>
-                      <button onClick={(e)=>{ e.stopPropagation(); if(confirm('Delete this course?')) removeCourse(c.id); }} className="w-full sm:w-auto inline-flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-sm bg-white border border-black/10 text-rose-600 shadow-sm hover:bg-rose-50">Delete</button>
+                    <div className="mt-3 flex items-center gap-2">
+                      <button
+                        onClick={(e) => { e.stopPropagation(); open(c.id); }}
+                        className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-slate-900 p-2 text-white shadow"
+                        aria-label="Open course"
+                      >
+                        <BookOpen className="icon" />
+                      </button>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); duplicateCourse(c.id); }}
+                        className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-black/10 bg-white p-2 shadow-sm hover:bg-slate-50"
+                        aria-label="Duplicate course"
+                      >
+                        <Copy className="icon" />
+                      </button>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); if (confirm('Delete this course?')) removeCourse(c.id); }}
+                        className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-black/10 bg-white p-2 text-rose-600 shadow-sm hover:bg-rose-50"
+                        aria-label="Delete course"
+                      >
+                        <Trash2 className="icon" />
+                      </button>
                     </div>
                   </motion.div>
                 );


### PR DESCRIPTION
## Summary
- ensure course cards span full width on home page
- replace Open/Duplicate/Delete text buttons with icons

## Testing
- `npm test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c820cf6fb4832ba5a286233008dee4