### PR TITLE
Fix course card overflow on mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2067,7 +2067,7 @@ export function CoursesHub({
               <button onClick={onAddCourse} className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm bg-black text-white shadow">Add Course</button>
             </div>
           ) : (
-            <div className="grid w-full gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {courses.map((c) => {
                 const t = computeTotals(c);
                 return (


### PR DESCRIPTION
## Summary
- ensure the courses grid defaults to a single column so cards respect the viewport on small screens

## Testing
- npm test *(fails: local Vitest binary is unavailable in the environment)*
- npx vitest run *(fails: registry access returned HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c88f89438c832ba91d920dfb496488