### PR TITLE
Fix course card overflow on mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -337,7 +337,7 @@ function CoursePMApp({ boot, isTemplateLabel = false, onBack, onStateChange, peo
     }
   }, [state, onStateChange]);
 
-const handleSave = async () => {
+const handleSave = useCallback(async () => {
   setSaveState('saving');
   const all = loadCourses();
   const idx = all.findIndex(
@@ -349,7 +349,13 @@ const handleSave = async () => {
   await saveCoursesRemote(all);
   onStateChange?.(state);
   setSaveState('saved');
-};
+}, [state, onStateChange]);
+
+useEffect(() => {
+  if (saveState !== 'unsaved') return;
+  const t = setTimeout(handleSave, 1500);
+  return () => clearTimeout(t);
+}, [saveState, handleSave]);
 
   // Listen for global schedule changes from other tabs
   useEffect(() => {
@@ -2067,7 +2073,7 @@ export function CoursesHub({
               <button onClick={onAddCourse} className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm bg-black text-white shadow">Add Course</button>
             </div>
           ) : (
-            <div className="grid w-full gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {courses.map((c) => {
                 const t = computeTotals(c);
                 return (


### PR DESCRIPTION
## Summary
- ensure the courses grid defaults to a single column so cards respect the viewport on small screens
- automatically persist course edits after a short delay

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest run` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c88f89438c832ba91d920dfb496488