### PR TITLE
Default course tasks to list view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -320,7 +320,7 @@ function CoursePMApp({ boot, isTemplateLabel = false, onBack, onStateChange, peo
     }
     return { ...base, schedule: loadGlobalSchedule() };
   });
-  const [view, setView] = useState("board");
+  const [view, setView] = useState("list");
   const [milestoneFilter, setMilestoneFilter] = useState("all");
   const isMobile = useIsMobile();
   const [milestonesCollapsed, setMilestonesCollapsed] = useState(isMobile);


### PR DESCRIPTION
## Summary
- default the course tasks view to the list layout when the dashboard section is expanded

## Testing
- npm test -- --run *(fails: vitest not installed prior to running tests due to registry access restrictions)*
- npm install *(fails: registry returned 403 for @tailwindcss/forms in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a6abf18c832ba2681fcc24120051