### PR TITLE
Update course dashboard milestones and task styling

### DIFF
--- a/src/TaskCard.jsx
+++ b/src/TaskCard.jsx
@@ -20,7 +20,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
   const soundEnabled = useContext(SoundContext);
   const audioCtxRef = useRef(null);
   const controls = useAnimation();
-  const statusColors = { todo: '#ffffff', inprogress: '#ecfdf5', done: '#d1fae5' };
+  const statusColors = { todo: '#ffffff', inprogress: '#dcfce7', done: '#fce7f3' };
   useEffect(() => { controls.set({ backgroundColor: statusColors[t.status], scale: 1 }); }, []);
   useEffect(() => {
     controls.start({
@@ -59,9 +59,9 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
     if (collapsed) setMilestoneEdit(false);
   }, [collapsed]);
   const statusPillClass = (status) => {
-    if (status === 'done') return 'bg-emerald-200/80 text-emerald-900 border-emerald-300';
-    if (status === 'inprogress') return 'bg-emerald-100 text-emerald-900 border-emerald-300';
-    return 'bg-slate-100 text-slate-700 border-slate-300';
+    if (status === 'done') return 'bg-pink-100 text-pink-800 border-pink-200';
+    if (status === 'inprogress') return 'bg-emerald-100 text-emerald-900 border-emerald-200';
+    return 'bg-white text-slate-700 border-slate-300';
   };
   const statusPillBase = 'min-w-[10rem] px-3 pr-10 py-1 rounded-full border font-semibold text-sm';
   const handleStatusChange = (value) => {

--- a/src/components/TeamMembersSection.jsx
+++ b/src/components/TeamMembersSection.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Plus, X } from "lucide-react";
+import { Plus, X, ChevronDown, ChevronUp } from "lucide-react";
 import { rolePalette } from "../utils.js";
 import Avatar from "./Avatar.jsx";
 
@@ -73,54 +73,77 @@ export default function TeamMembersSection({
   onOpenUser,
   courseLDIds = [],
   courseSMEIds = [],
+  collapsed = false,
+  onToggle = () => {},
 }) {
   return (
     <section className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
-      <div className="flex flex-col sm:flex-row items-center justify-between gap-2 mb-2">
-        <h2 className="font-semibold flex items-center gap-2">👥︎ Team Members</h2>
-        <div className="flex items-center gap-2">
-          <select
-            value=""
-            onChange={(e) => {
-              if (e.target.value) {
-                onAddExistingMember(e.target.value);
-                e.target.value = "";
-              }
-            }}
-            className="text-sm"
-          >
-            <option value="">Add existing...</option>
-            {people
-              .filter((p) => !team.some((m) => m.id === p.id))
-              .map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.name}
-                </option>
-              ))}
-          </select>
+      <div
+        className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-2 px-1 cursor-pointer"
+        onClick={onToggle}
+      >
+        <h2 className="font-semibold flex items-center gap-2">
+          👥︎ Team Members
+          <span className="text-sm font-normal text-black/60">({team.length})</span>
+        </h2>
+        <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+          {!collapsed && (
+            <>
+              <select
+                value=""
+                onChange={(e) => {
+                  if (e.target.value) {
+                    onAddExistingMember(e.target.value);
+                    e.target.value = "";
+                  }
+                }}
+                className="text-sm"
+              >
+                <option value="">Add existing...</option>
+                {people
+                  .filter((p) => !team.some((m) => m.id === p.id))
+                  .map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+              </select>
+              <button
+                onClick={onAddMember}
+                className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
+                aria-label="Add member"
+              >
+                <Plus className="icon" />
+              </button>
+            </>
+          )}
           <button
-            onClick={onAddMember}
-            className="inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-white border border-black/10 shadow-sm hover:bg-slate-50"
-            aria-label="Add member"
+            type="button"
+            onClick={onToggle}
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? "Expand team members" : "Collapse team members"}
+            className="inline-flex items-center justify-center w-9 h-9 sm:w-11 sm:h-11 rounded-full border border-black/10 bg-white text-slate-600 hover:bg-slate-50"
           >
-            <Plus className="icon" />
+            {collapsed ? <ChevronDown className="icon" /> : <ChevronUp className="icon" />}
           </button>
         </div>
       </div>
-      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-3">
-        {team.map((m) => (
-          <TeamMemberCard
-            key={m.id}
-            member={m}
-            courseLDIds={courseLDIds}
-            courseSMEIds={courseSMEIds}
-            onUpdate={onUpdateMember}
-            onDelete={onDeleteMember}
-            onToggleCourseWide={onToggleCourseWide}
-            onOpenUser={onOpenUser}
-          />
-        ))}
-      </div>
+      {!collapsed && (
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-3">
+          {team.map((m) => (
+            <TeamMemberCard
+              key={m.id}
+              member={m}
+              courseLDIds={courseLDIds}
+              courseSMEIds={courseSMEIds}
+              onUpdate={onUpdateMember}
+              onDelete={onDeleteMember}
+              onToggleCourseWide={onToggleCourseWide}
+              onOpenUser={onOpenUser}
+            />
+          ))}
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- expand course dashboard milestones by default, collapse team members with a new toggle, and swap the dropdown filter for an icon-driven menu
- update task card color coding to use white for to do, green for in progress, and pink for done
- overhaul the user milestone tab to show status-sorted task lists that open the task editor instead of milestone cards
- add a segmented progress bar to collapsed milestone summaries in the user dashboard so completion is visible at a glance

## Testing
- `npm test -- --watch=false` *(fails: vitest command unavailable because dependencies are not installed in this environment)*
- `npm install` *(fails: npm registry access returns 403 for @tailwindcss/forms in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ab3a681c832b8e16ee2d1c3b07ac