### PR TITLE
Align assignee selects with date inputs

### DIFF
--- a/src/TaskCard.jsx
+++ b/src/TaskCard.jsx
@@ -183,7 +183,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                     aria-label="Assignee"
                     value={t.assigneeId || ''}
                     onChange={(e) => update(t.id, { assigneeId: e.target.value || null })}
-                    className="border rounded px-1.5 py-1"
+                    className="w-20 border rounded px-1.5 py-1"
                   >
                     <option value="">Unassigned</option>
                     {team.map((m) => (
@@ -290,7 +290,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                 aria-label="Assignee"
                 value={t.assigneeId || ''}
                 onChange={(e) => update(t.id, { assigneeId: e.target.value || null })}
-                className="border rounded px-1.5 py-1"
+                className="w-20 border rounded px-1.5 py-1"
               >
                 <option value="">Unassigned</option>
                 {team.map((m) => (


### PR DESCRIPTION
## Summary
- add the `w-20` width utility to both assignee select elements so they align with the start-date and workday inputs

## Testing
- `npm test -- --run` *(fails: vitest not found before dependencies could be installed)*
- `npm install` *(fails: registry access returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c90af290d0832b95405a8cb6e6dc8b