### PR TITLE
Make team member cards accessible to keyboard users

### DIFF
--- a/src/components/TeamMembersSection.jsx
+++ b/src/components/TeamMembersSection.jsx
@@ -13,10 +13,21 @@ function TeamMemberCard({
   onOpenUser,
 }) {
   const courseWide = member.roleType === "LD" ? courseLDIds : courseSMEIds;
+  const openUser = () => {
+    onOpenUser?.(member.id);
+  };
   return (
     <div
       className="group rounded-xl border border-black/10 p-3 flex items-center justify-between cursor-pointer"
-      onClick={() => onOpenUser(member.id)}
+      role="button"
+      tabIndex={0}
+      onClick={openUser}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          openUser();
+        }
+      }}
     >
       <div className="flex items-center gap-2 min-w-0">
         <Avatar name={member.name} roleType={member.roleType} avatar={member.avatar} />


### PR DESCRIPTION
## Summary
- create an `openUser` helper for team member cards to guard the optional callback
- treat the card container as a button so it can be activated with clicks or the keyboard

## Testing
- npm test *(fails: vitest not found before installing dependencies)*
- npm install *(fails: 403 Forbidden when fetching @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68c9168640c8832b99267dc171540921