### PR TITLE
Adjust TaskCard assignee select width

### DIFF
--- a/src/TaskCard.jsx
+++ b/src/TaskCard.jsx
@@ -183,7 +183,8 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                     aria-label="Assignee"
                     value={t.assigneeId || ''}
                     onChange={(e) => update(t.id, { assigneeId: e.target.value || null })}
-                    className="w-20 border rounded px-1.5 py-1"
+                    className="min-w-[8rem] max-w-full w-auto border rounded px-1.5 py-1 flex-1"
+                    title={team.find((m) => m.id === t.assigneeId)?.name}
                   >
                     <option value="">Unassigned</option>
                     {team.map((m) => (
@@ -291,7 +292,8 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                 aria-label="Assignee"
                 value={t.assigneeId || ''}
                 onChange={(e) => update(t.id, { assigneeId: e.target.value || null })}
-                className="w-20 border rounded px-1.5 py-1"
+                className="min-w-[8rem] max-w-full w-auto border rounded px-1.5 py-1 flex-1"
+                title={team.find((m) => m.id === t.assigneeId)?.name}
               >
                 <option value="">Unassigned</option>
                 {team.map((m) => (


### PR DESCRIPTION
## Summary
- let the TaskCard assignee selectors grow with name length instead of locking to a tiny width
- surface the full assignee name via the select title to aid hover previews

## Testing
- npm install *(fails: 403 Forbidden while fetching @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68c918744564832b91c80cc6c0de8946