### PR TITLE
Adjust milestone filter dropdown for mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -902,7 +902,7 @@ useEffect(() => {
                         <span className="max-w-[10rem] truncate">{activeFilterLabel}</span>
                       </button>
                       {milestoneFilterOpen && (
-                        <div className="absolute right-0 mt-2 w-60 glass-surface p-2 z-10 flex flex-col gap-1">
+                        <div className="absolute left-4 right-4 sm:left-auto sm:right-0 mt-2 max-h-[70vh] sm:max-h-none overflow-y-auto glass-surface p-2 z-20 flex flex-col gap-1 w-auto sm:w-60">
                           <button
                             type="button"
                             onClick={() => { setMilestoneFilter('all'); setMilestoneFilterOpen(false); }}


### PR DESCRIPTION
## Summary
- keep the milestone filter menu within the viewport on narrow screens by offsetting it from the container edges
- constrain the dropdown height with scrolling so long lists of milestones are accessible and raise its stacking order

## Testing
- npm test *(fails: vitest is not installed because `npm install` cannot reach the registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c95980aa50832b9608dd0567763851