### PR TITLE
Polish progress ring and course task checklist styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -281,6 +281,7 @@ function Ring({ className = "w-20 h-20", stroke = 10, progress = 0, trackOpacity
   const c = 2 * Math.PI * r;
   const pct = clamp(progress, 0, 100);
   const dash = (pct / 100) * c;
+  const inset = Math.max(stroke, 8);
   return (
     <div className={`relative inline-flex items-center justify-center ${className}`}>
       <svg viewBox="0 0 100 100" className="absolute inset-0 rotate-[-90deg]">
@@ -305,7 +306,19 @@ function Ring({ className = "w-20 h-20", stroke = 10, progress = 0, trackOpacity
           fill="none"
         />
       </svg>
-      <div className="absolute inset-0 grid place-items-center text-center select-none">{children}</div>
+      <div
+        className="absolute flex flex-col items-center justify-center rounded-full text-center select-none"
+        style={{
+          top: `${inset}px`,
+          right: `${inset}px`,
+          bottom: `${inset}px`,
+          left: `${inset}px`,
+          backgroundColor: "rgba(255, 255, 255, 0.96)",
+          boxShadow: "inset 0 1px 4px rgba(15, 23, 42, 0.08)",
+        }}
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/components/TaskChecklist.jsx
+++ b/src/components/TaskChecklist.jsx
@@ -2,6 +2,8 @@ import React, { useMemo } from "react";
 
 export default function TaskChecklist({ tasks, team, milestones, onUpdate, onEdit }) {
   const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const todayKey = today.toDateString();
   const { activeGroups, doneTasks } = useMemo(() => {
     const upcoming = [];
     const completed = [];
@@ -45,42 +47,68 @@ export default function TaskChecklist({ tasks, team, milestones, onUpdate, onEdi
       {activeGroups.length > 0 && (
         <ul className="space-y-2">
           {activeGroups.map(([date, items]) => (
-            <li key={date} className="rounded-xl border border-black/10 bg-white p-3 w-full">
-              <div className="text-sm font-medium mb-1">
+            <li key={date} className="glass-card p-4 w-full space-y-3">
+              <div className="text-sm font-semibold text-slate-700/90">
                 {date === "none" ? "No due date" : formatDate(date)}
               </div>
-              <ul className="space-y-1">
+              <ul className="space-y-2">
                 {items.map((t) => {
                   const milestone = milestones.find((m) => m.id === t.milestoneId);
                   const assignee = team.find((m) => m.id === t.assigneeId);
-                  const urgentClass =
-                    t.dueDate && new Date(t.dueDate) < today
-                      ? "bg-rose-100 text-rose-800"
-                      : t.dueDate && new Date(t.dueDate).toDateString() === today.toDateString()
-                      ? "bg-amber-100 text-amber-800"
-                      : "bg-slate-100";
+                  const dueDate = t.dueDate ? new Date(t.dueDate) : null;
+                  const dueKey = dueDate ? dueDate.toDateString() : "";
+                  const isOverdue = !!dueDate && dueDate < today;
+                  const isDueToday = !!dueDate && dueKey === todayKey;
+                  const containerTone = isOverdue
+                    ? "border-rose-200/80 bg-rose-50/80 text-rose-700/90"
+                    : isDueToday
+                    ? "border-amber-200/80 bg-amber-50/80 text-amber-700/90"
+                    : "border-white/60 bg-white/80 text-slate-700";
+                  const pillTone = isOverdue
+                    ? "bg-rose-100/80 text-rose-700 border-rose-200/80"
+                    : isDueToday
+                    ? "bg-amber-100/80 text-amber-700 border-amber-200/80"
+                    : t.dueDate
+                    ? "bg-white/80 text-slate-600 border-white/60"
+                    : "bg-slate-100/80 text-slate-600 border-white/60";
+                  const pillLabel = isOverdue
+                    ? "Overdue"
+                    : isDueToday
+                    ? "Today"
+                    : t.dueDate
+                    ? "Scheduled"
+                    : "No Date";
                   return (
-                    <li
-                      key={t.id}
-                      className={`text-sm flex items-center gap-1 truncate w-full rounded px-2 py-1 ${urgentClass}`}
-                    >
-                      <input
-                        type="checkbox"
-                        className="rounded border-slate-300"
-                        aria-label={`${t.title} for ${milestone ? milestone.title : "Unassigned"}`}
-                        checked={t.status === "done"}
-                        onChange={(e) => onUpdate(t.id, { status: e.target.checked ? "done" : "todo" })}
-                      />
-                      <button
-                        onClick={() => onEdit(t.id)}
-                        className="truncate text-left flex-1"
-                        title={`${t.title}${milestone ? ` – ${milestone.title}` : " – Unassigned"}`}
+                    <li key={t.id}>
+                      <div
+                        className={`flex items-center gap-3 rounded-3xl border px-4 py-3 shadow-[0_18px_32px_-20px_rgba(15,23,42,0.45)] backdrop-blur transition-all ${containerTone}`}
                       >
-                        {t.title} {" "}
-                        <span className="text-black/60">
-                          for {milestone ? milestone.title : "Unassigned"} — {assignee ? assignee.name : "Unassigned"}
+                        <input
+                          type="checkbox"
+                          className="h-5 w-5 shrink-0 rounded-full border-2 border-slate-300 text-emerald-500 focus:ring-2 focus:ring-emerald-300"
+                          aria-label={`${t.title} for ${milestone ? milestone.title : "Unassigned"}`}
+                          checked={t.status === "done"}
+                          onChange={(e) => onUpdate(t.id, { status: e.target.checked ? "done" : "todo" })}
+                        />
+                        <button
+                          type="button"
+                          onClick={() => onEdit(t.id)}
+                          className="flex-1 min-w-0 text-left focus:outline-none"
+                          title={`${t.title || "Untitled task"}${milestone ? ` – ${milestone.title}` : " – Unassigned"}`}
+                        >
+                          <div className="truncate text-[15px] font-medium leading-tight">
+                            {t.title || "Untitled task"}
+                          </div>
+                          <div className="mt-0.5 truncate text-xs opacity-70">
+                            for {milestone ? milestone.title : "Unassigned"} • {assignee ? assignee.name : "Unassigned"}
+                          </div>
+                        </button>
+                        <span
+                          className={`shrink-0 self-start rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide shadow-sm backdrop-blur ${pillTone}`}
+                        >
+                          {pillLabel}
                         </span>
-                      </button>
+                      </div>
                     </li>
                   );
                 })}
@@ -93,37 +121,40 @@ export default function TaskChecklist({ tasks, team, milestones, onUpdate, onEdi
       {doneTasks.length > 0 && (
         <div>
           <div className="text-sm font-semibold text-slate-600 mb-2">Completed Tasks</div>
-          <ul className="space-y-1">
+          <ul className="space-y-2">
             {doneTasks.map((t) => {
               const milestone = milestones.find((m) => m.id === t.milestoneId);
               const assignee = team.find((m) => m.id === t.assigneeId);
               return (
-                <li
-                  key={t.id}
-                  className="text-sm flex flex-wrap items-center gap-x-2 gap-y-1 rounded border border-emerald-200 bg-emerald-50 px-2 py-1 text-emerald-900"
-                >
-                  <div className="flex items-center gap-1 flex-1 min-w-0">
+                <li key={t.id}>
+                  <div className="flex items-center gap-3 rounded-3xl border border-emerald-200/80 bg-emerald-50/80 px-4 py-3 text-emerald-700 shadow-[0_18px_32px_-20px_rgba(15,23,42,0.45)] backdrop-blur">
                     <input
                       type="checkbox"
-                      className="rounded border-emerald-300"
+                      className="h-5 w-5 shrink-0 rounded-full border-2 border-emerald-300 text-emerald-600 focus:ring-2 focus:ring-emerald-300"
                       aria-label={`${t.title} for ${milestone ? milestone.title : "Unassigned"}`}
                       checked
                       onChange={(e) => onUpdate(t.id, { status: e.target.checked ? "done" : "todo" })}
                     />
                     <button
+                      type="button"
                       onClick={() => onEdit(t.id)}
-                      className="truncate text-left flex-1"
-                      title={`${t.title}${milestone ? ` – ${milestone.title}` : " – Unassigned"}`}
+                      className="flex-1 min-w-0 text-left focus:outline-none"
+                      title={`${t.title || "Untitled task"}${milestone ? ` – ${milestone.title}` : " – Unassigned"}`}
                     >
-                      {t.title} {" "}
-                      <span className="text-emerald-700">
-                        for {milestone ? milestone.title : "Unassigned"} — {assignee ? assignee.name : "Unassigned"}
-                      </span>
+                      <div className="truncate text-[15px] font-medium leading-tight">
+                        {t.title || "Untitled task"}
+                      </div>
+                      <div className="mt-0.5 truncate text-xs opacity-70">
+                        for {milestone ? milestone.title : "Unassigned"} • {assignee ? assignee.name : "Unassigned"}
+                      </div>
+                      <div className="mt-1 text-xs font-semibold opacity-80">
+                        Completed: {t.completedDate ? formatDate(t.completedDate) : "—"}
+                      </div>
                     </button>
+                    <span className="shrink-0 self-start rounded-full border border-emerald-200/80 bg-white/80 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-emerald-700 shadow-sm">
+                      Done
+                    </span>
                   </div>
-                  <span className="text-xs text-emerald-700 ml-auto">
-                    Completed: {t.completedDate ? formatDate(t.completedDate) : "—"}
-                  </span>
                 </li>
               );
             })}


### PR DESCRIPTION
## Summary
- add an inset center capsule to the Ring component so text no longer touches the circular stroke
- restyle course task checklist items to mirror the user dashboard’s Apple-inspired cards with due date pills
- refresh the completed tasks list to use the same elevated styling and completion details

## Testing
- npm test *(fails: vitest not installed because npm install is blocked by registry 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c95d095c2c832b8c2445129dc06d21