### PR TITLE
Allow adding tasks from collapsed milestones

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -542,7 +542,7 @@ useEffect(() => {
 
   const team = state.team;
   const milestones = useMemo(
-    () => [...state.milestones].sort((a, b) => a.title.localeCompare(b.title)),
+    () => [...state.milestones],
     [state.milestones]
   );
   const tasksRaw = state.tasks;
@@ -664,7 +664,7 @@ useEffect(() => {
   const addMilestone = () =>
     updateCourseState((s) => ({
       ...s,
-      milestones: [...s.milestones, { id: uid(), title: "New Milestone", start: todayStr(), goal: "" }],
+      milestones: [{ id: uid(), title: "New Milestone", start: todayStr(), goal: "" }, ...s.milestones],
     }));
   const addMilestoneFromTemplate = (tplId) =>
     updateCourseState((s) => {
@@ -685,7 +685,7 @@ useEffect(() => {
         dueDate: '',
         completedDate: '',
       }));
-      return { ...s, milestones: [...s.milestones, newMs], tasks: [...s.tasks, ...clonedTasks] };
+      return { ...s, milestones: [newMs, ...s.milestones], tasks: [...s.tasks, ...clonedTasks] };
     });
   const deleteMilestone  = (id) =>
     updateCourseState((s) => {
@@ -1284,6 +1284,7 @@ useEffect(() => {
                       onDeleteMilestone={deleteMilestone}
                       onUpdateMilestone={updateMilestone}
                       onSaveAsTemplate={saveMilestoneTemplate}
+                      onAddTask={addTask}
                       onAddLink={(id, url) => patchTaskLinks(id, 'add', url)}
                       onRemoveLink={(id, idx) => patchTaskLinks(id, 'remove', idx)}
                     />

--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -1,6 +1,6 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect, useRef } from 'react';
 import TaskCard from './TaskCard.jsx';
-import { Copy, Save, Trash, ChevronDown } from 'lucide-react';
+import { Copy, Save, Trash, ChevronDown, Plus } from 'lucide-react';
 
 export default function MilestoneCard({
   milestone,
@@ -17,10 +17,14 @@ export default function MilestoneCard({
   onRemoveLink,
   onUpdateMilestone,
   onSaveAsTemplate,
+  onAddTask,
 }) {
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState(milestone.title);
+  const detailsRef = useRef(null);
+
   useEffect(() => setTitleDraft(milestone.title), [milestone.title]);
+
   const commitTitle = () => {
     setEditingTitle(false);
     if (titleDraft !== milestone.title) {
@@ -34,17 +38,29 @@ export default function MilestoneCard({
     const done = tasks.filter((t) => t.status === 'done').length;
     const pct = tasks.length ? Math.round((done / tasks.length) * 100) : 0;
     const tasksSorted = [...tasks].sort(
-      (a, b) =>
-        statusOrder[a.status] - statusOrder[b.status] || a.order - b.order,
+      (a, b) => statusOrder[a.status] - statusOrder[b.status] || a.order - b.order,
     );
     return { done, pct, tasksSorted };
   }, [tasks]);
 
   const progressColor = `hsl(${330 + (pct / 100) * (120 - 330)}, 70%, 50%)`;
 
-    return (
-      <details className="group rounded-xl border border-black/10 bg-white">
-        <summary className="cursor-pointer select-none p-4 flex flex-wrap items-center justify-between gap-2 list-none [&::-webkit-details-marker]:hidden">
+  const triggerAddTask = () => {
+    if (detailsRef.current) {
+      detailsRef.current.open = true;
+    }
+    onAddTask?.(milestone.id);
+  };
+
+  const handleAddTaskFromSummary = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    triggerAddTask();
+  };
+
+  return (
+    <details ref={detailsRef} className="group rounded-xl border border-black/10 bg-white">
+      <summary className="cursor-pointer select-none p-4 flex flex-wrap items-center justify-between gap-2 list-none [&::-webkit-details-marker]:hidden">
         <div className="flex items-center gap-2 flex-1">
           <ChevronDown className="icon transition-transform group-open:rotate-180" />
           <div className="flex-1">
@@ -79,64 +95,78 @@ export default function MilestoneCard({
             ) : (
               <div className="font-semibold">{milestone.title}</div>
             )}
-              <div className="h-2 bg-black/10 rounded-full mt-2 overflow-hidden">
-                <div
-                  data-testid="progress-fill"
-                  className="h-full"
-                  style={{ width: `${pct}%`, backgroundColor: progressColor }}
-                />
-              </div>
+            <div className="h-2 bg-black/10 rounded-full mt-2 overflow-hidden">
+              <div
+                data-testid="progress-fill"
+                className="h-full"
+                style={{ width: `${pct}%`, backgroundColor: progressColor }}
+              />
             </div>
           </div>
-          <div className="flex items-center gap-1 flex-wrap">
-            {onDuplicateMilestone && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDuplicateMilestone(milestone.id);
-                }}
-                className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
-                title="Duplicate Milestone"
-                aria-label="Duplicate Milestone"
-              >
-                <Copy className="icon" />
-              </button>
-            )}
-            {onSaveAsTemplate && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onSaveAsTemplate(milestone.id);
-                }}
-                className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-black/10 bg-green-50 text-green-600 hover:bg-green-100"
-                title="Save as Milestone Template"
-                aria-label="Save as Milestone Template"
-              >
-                <Save className="icon" />
-              </button>
-            )}
-            {onDeleteMilestone && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDeleteMilestone(milestone.id);
-                }}
-                className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
-                title="Remove Milestone"
-                aria-label="Remove Milestone"
-              >
-                <Trash className="icon" />
-              </button>
-            )}
-          </div>
-        </summary>
-        <div className="p-4 flex flex-col gap-2">
-          {milestone.goal && (
-            <p className="text-sm text-black/60 mb-2">{milestone.goal}</p>
+        </div>
+        <div className="flex items-center gap-1 flex-wrap">
+          {onAddTask && (
+            <button
+              type="button"
+              onClick={handleAddTaskFromSummary}
+              className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-indigo-200 bg-indigo-50 text-indigo-600 hover:bg-indigo-100"
+              title="Add task"
+              aria-label="Add task"
+            >
+              <Plus className="icon" />
+            </button>
           )}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-            {tasksSorted.map((t) => (
-              <TaskCard
+          {onDuplicateMilestone && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDuplicateMilestone(milestone.id);
+              }}
+              className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
+              title="Duplicate Milestone"
+              aria-label="Duplicate Milestone"
+              type="button"
+            >
+              <Copy className="icon" />
+            </button>
+          )}
+          {onSaveAsTemplate && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onSaveAsTemplate(milestone.id);
+              }}
+              className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-black/10 bg-green-50 text-green-600 hover:bg-green-100"
+              title="Save as Milestone Template"
+              aria-label="Save as Milestone Template"
+              type="button"
+            >
+              <Save className="icon" />
+            </button>
+          )}
+          {onDeleteMilestone && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDeleteMilestone(milestone.id);
+              }}
+              className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-black/10 bg-slate-100 text-slate-600 hover:bg-slate-200"
+              title="Remove Milestone"
+              aria-label="Remove Milestone"
+              type="button"
+            >
+              <Trash className="icon" />
+            </button>
+          )}
+        </div>
+      </summary>
+      <div className="p-4 flex flex-col gap-2">
+        {milestone.goal && (
+          <p className="text-sm text-black/60 mb-2">{milestone.goal}</p>
+        )}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+          {tasksSorted.map((t) => (
+            <TaskCard
               key={t.id}
               task={t}
               tasks={tasksAll}
@@ -150,8 +180,19 @@ export default function MilestoneCard({
             />
           ))}
         </div>
+        {onAddTask && (
+          <div className="flex justify-end pt-2">
+            <button
+              type="button"
+              onClick={triggerAddTask}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-1.5 text-sm font-medium text-indigo-700 hover:bg-indigo-100"
+            >
+              <Plus className="icon" />
+              <span>Add Task</span>
+            </button>
+          </div>
+        )}
       </div>
     </details>
   );
 }
-

--- a/src/MilestoneCard.test.jsx
+++ b/src/MilestoneCard.test.jsx
@@ -30,5 +30,19 @@ describe('MilestoneCard', () => {
     const bar = screen.getByTestId('progress-fill');
     expect(bar.getAttribute('style')).toContain(`background-color: ${color}`);
   });
+
+  it('adds tasks from the collapsed summary button', () => {
+    const onAddTask = vi.fn();
+    const { container } = render(
+      <MilestoneCard milestone={milestone} onAddTask={onAddTask} />,
+    );
+
+    const addButton = screen.getByLabelText(/add task/i);
+    fireEvent.click(addButton);
+
+    expect(onAddTask).toHaveBeenCalledWith('m1');
+    const details = container.querySelector('details');
+    expect(details?.open).toBe(true);
+  });
 });
 


### PR DESCRIPTION
## Summary
- keep milestone ordering stable so that newly created milestones appear at the top of the stack
- add quick "Add task" controls to milestone cards, opening the panel even when collapsed
- cover the new milestone-card behavior with a unit test

## Testing
- npm test *(fails: vitest missing because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca556a84dc832b9e51b77997a5d57c