### PR TITLE
Sort collapsed milestones alphabetically

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -560,7 +560,14 @@ useEffect(() => {
       return id === null || id === undefined || id === "" || !validIds.has(id);
     });
   }, [tasksRaw, milestones]);
-  const filteredMilestones = useMemo(() => (milestoneFilter === "all" ? milestones : milestones.filter((m) => m.id === milestoneFilter)), [milestones, milestoneFilter]);
+  const filteredMilestones = useMemo(() => {
+    const base =
+      milestoneFilter === "all"
+        ? milestones
+        : milestones.filter((m) => m.id === milestoneFilter);
+    if (!milestonesCollapsed) return base;
+    return [...base].sort((a, b) => a.title.localeCompare(b.title));
+  }, [milestones, milestoneFilter, milestonesCollapsed]);
   const activeFilterLabel = useMemo(() => {
     if (milestoneFilter === "all") return "All milestones";
     const match = milestones.find((m) => m.id === milestoneFilter);
@@ -3083,6 +3090,8 @@ export function CoursesHub({
 // =====================================================
 // Root App – switches between Hub and Course Dashboard
 // =====================================================
+export { CoursePMApp };
+
 export default function PMApp() {
   const [view, setView] = useState(() => {
     const hasCourses = loadCourses().length > 0; return hasCourses ? "hub" : "hub"; // start at hub

--- a/src/CoursePMApp.test.jsx
+++ b/src/CoursePMApp.test.jsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, beforeEach, beforeAll, expect, vi } from 'vitest';
+import { CoursePMApp } from './App.jsx';
+
+vi.mock('./firebase.js', () => ({ db: {} }));
+vi.mock('firebase/firestore', () => ({
+  getDoc: vi.fn().mockResolvedValue({ exists: () => false }),
+  setDoc: vi.fn().mockResolvedValue(),
+  doc: vi.fn(),
+}));
+
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    getItem: (key) => (key in store ? store[key] : null),
+    setItem: (key, value) => {
+      store[key] = String(value);
+    },
+    removeItem: (key) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+vi.stubGlobal('localStorage', localStorageMock);
+
+beforeAll(() => {
+  window.matchMedia = window.matchMedia || (() => ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }));
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+const createBootState = () => ({
+  course: {
+    id: 'course-1',
+    name: 'Test Course',
+    description: '',
+    accent: 'from-slate-500 via-slate-500 to-slate-500',
+    courseLDIds: [],
+    courseSMEIds: [],
+  },
+  schedule: { workweek: [1, 2, 3, 4, 5], holidays: [] },
+  team: [],
+  milestones: [
+    { id: 'm1', title: 'Gamma' },
+    { id: 'm2', title: 'Alpha' },
+    { id: 'm3', title: 'Beta' },
+  ],
+  tasks: [],
+});
+
+describe('CoursePMApp milestones collapse ordering', () => {
+  const renderApp = () =>
+    render(
+      <CoursePMApp
+        boot={createBootState()}
+        onBack={() => {}}
+        onStateChange={() => {}}
+        people={[]}
+        milestoneTemplates={[]}
+        onChangeMilestoneTemplates={() => {}}
+        onOpenUser={() => {}}
+      />
+    );
+
+  const getMilestoneTitles = (section) =>
+    Array.from(section.querySelectorAll('details > summary .font-semibold'))
+      .map((el) => el.textContent.trim())
+      .filter(Boolean);
+
+  it('preserves manual ordering when expanded and sorts alphabetically when collapsed', () => {
+    renderApp();
+    const heading = screen.getByRole('heading', { name: 'Milestones' });
+    const section = heading.closest('section');
+    expect(section).not.toBeNull();
+
+    expect(getMilestoneTitles(section)).toEqual(['Gamma', 'Alpha', 'Beta']);
+
+    const collapseButton = screen.getByRole('button', { name: /collapse milestones/i });
+    fireEvent.click(collapseButton);
+
+    expect(getMilestoneTitles(section)).toEqual(['Alpha', 'Beta', 'Gamma']);
+  });
+});


### PR DESCRIPTION
## Summary
- sort collapsed milestones alphabetically while keeping the drag-and-drop order when expanded
- expose `CoursePMApp` for reuse in tests
- add a regression test that covers the collapsed milestone ordering

## Testing
- npm test -- --run *(fails: vitest missing because dependencies cannot be installed — npm install returns 403 for @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68ca71b81c08832baf72e6ac056fc333