### PR TITLE
Sort milestones alphabetically

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -565,9 +565,10 @@ useEffect(() => {
       milestoneFilter === "all"
         ? milestones
         : milestones.filter((m) => m.id === milestoneFilter);
-    if (!milestonesCollapsed) return base;
-    return [...base].sort((a, b) => a.title.localeCompare(b.title));
-  }, [milestones, milestoneFilter, milestonesCollapsed]);
+    return [...base].sort((a, b) =>
+      (a.title || "").localeCompare(b.title || "", undefined, { sensitivity: "base" })
+    );
+  }, [milestones, milestoneFilter]);
   const activeFilterLabel = useMemo(() => {
     if (milestoneFilter === "all") return "All milestones";
     const match = milestones.find((m) => m.id === milestoneFilter);
@@ -2187,10 +2188,8 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
                       </summary>
                       <div className="p-4 space-y-2">
                         {[...c.milestones]
-                          .sort(
-                            (a, b) =>
-                              c.tasks.filter((t) => t.milestoneId === b.id).length -
-                              c.tasks.filter((t) => t.milestoneId === a.id).length
+                          .sort((a, b) =>
+                            (a.title || "").localeCompare(b.title || "", undefined, { sensitivity: 'base' })
                           )
                           .map((m) => {
                             const tasksForMilestone = c.tasks.filter(

--- a/src/CoursePMApp.test.jsx
+++ b/src/CoursePMApp.test.jsx
@@ -80,13 +80,13 @@ describe('CoursePMApp milestones collapse ordering', () => {
       .map((el) => el.textContent.trim())
       .filter(Boolean);
 
-  it('preserves manual ordering when expanded and sorts alphabetically when collapsed', () => {
+  it('sorts milestones alphabetically regardless of collapse state', () => {
     renderApp();
     const heading = screen.getByRole('heading', { name: 'Milestones' });
     const section = heading.closest('section');
     expect(section).not.toBeNull();
 
-    expect(getMilestoneTitles(section)).toEqual(['Gamma', 'Alpha', 'Beta']);
+    expect(getMilestoneTitles(section)).toEqual(['Alpha', 'Beta', 'Gamma']);
 
     const collapseButton = screen.getByRole('button', { name: /collapse milestones/i });
     fireEvent.click(collapseButton);


### PR DESCRIPTION
## Summary
- sort milestone lists alphabetically in the course dashboard and user dashboard views
- compare titles case-insensitively so existing and new milestones use a consistent order
- update the course dashboard test to reflect the always-alphabetical arrangement

## Testing
- npm test *(fails: vitest not available because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3a9be7dc832badb538c18221e85f