### PR TITLE
Add per-course link library section

### DIFF
--- a/src/seed.test.js
+++ b/src/seed.test.js
@@ -8,5 +8,7 @@ describe('seed()', () => {
     expect(Array.isArray(project.tasks)).toBe(true);
     expect(project.milestones).toHaveLength(0);
     expect(project.tasks).toHaveLength(0);
+    expect(Array.isArray(project.linkLibrary)).toBe(true);
+    expect(project.linkLibrary).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- add a collapsible Link Library section to each course dashboard and surface it before the dashboard metrics
- persist course-specific link entries in saved state, including seed defaults and migration sanitization
- extend the seed test coverage to ensure new course link libraries start empty

## Testing
- npm test *(fails: vitest command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb46907858832badf803ec4cb1ec71