### PR TITLE
Normalize URLs when adding links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -71,7 +71,8 @@ import {
   nextMemberName,
   isHoliday,
   isWorkday,
-  addBusinessDays
+  addBusinessDays,
+  normalizeUrl
 } from "./utils.js";
 
 /**
@@ -616,18 +617,9 @@ useEffect(() => {
       const label = newLinkLabel.trim();
       const rawUrl = newLinkUrl.trim();
       if (!rawUrl) return;
-      let parsed;
-      try {
-        parsed = new URL(rawUrl);
-      } catch {
-        try {
-          parsed = new URL(`https://${rawUrl}`);
-        } catch {
-          return;
-        }
-      }
-      if (!parsed) return;
-      const finalUrl = parsed.toString();
+      const finalUrl = normalizeUrl(rawUrl);
+      if (!finalUrl) return;
+      const parsed = new URL(finalUrl);
       const entry = {
         id: uid(),
         label: label || parsed.hostname || finalUrl,
@@ -1195,10 +1187,12 @@ useEffect(() => {
                   <label className="flex-1 text-sm text-slate-700">
                     <span className="font-medium">URL</span>
                     <input
-                      type="url"
+                      type="text"
+                      inputMode="url"
+                      autoComplete="url"
                       value={newLinkUrl}
                       onChange={(e) => setNewLinkUrl(e.target.value)}
-                      placeholder="https://example.com"
+                      placeholder="example.com or https://example.com"
                       className="mt-1 w-full rounded-2xl border border-white/60 bg-white/80 px-3 py-2 text-sm shadow-sm"
                     />
                   </label>
@@ -2626,18 +2620,9 @@ export function CoursesHub({
       const label = newLinkLabel.trim();
       const rawUrl = newLinkUrl.trim();
       if (!rawUrl) return;
-      let parsed;
-      try {
-        parsed = new URL(rawUrl);
-      } catch {
-        try {
-          parsed = new URL(`https://${rawUrl}`);
-        } catch {
-          return;
-        }
-      }
-      if (!parsed) return;
-      const finalUrl = parsed.toString();
+      const finalUrl = normalizeUrl(rawUrl);
+      if (!finalUrl) return;
+      const parsed = new URL(finalUrl);
       const entry = {
         id: uid(),
         label: label || parsed.hostname || finalUrl,
@@ -3064,10 +3049,12 @@ export function CoursesHub({
                   <label className="flex-1 text-sm text-slate-700">
                     <span className="font-medium">URL</span>
                     <input
-                      type="url"
+                      type="text"
+                      inputMode="url"
+                      autoComplete="url"
                       value={newLinkUrl}
                       onChange={(e) => setNewLinkUrl(e.target.value)}
-                      placeholder="https://example.com"
+                      placeholder="example.com or https://example.com"
                       className="mt-1 w-full rounded-2xl border border-white/60 bg-white/80 px-3 py-2 text-sm shadow-sm"
                     />
                   </label>

--- a/src/components/DocumentInput.jsx
+++ b/src/components/DocumentInput.jsx
@@ -1,16 +1,16 @@
 import React, { useState } from "react";
 import { Plus } from "lucide-react";
+import { normalizeUrl } from "../utils.js";
 
 export default function DocumentInput({ onAdd }) {
   const [val, setVal] = useState("");
   const add = () => {
     const url = val.trim();
     if (!url) return;
-    try {
-      const u = new URL(url);
-      onAdd?.(u.toString());
-      setVal("");
-    } catch {}
+    const normalized = normalizeUrl(url);
+    if (!normalized) return;
+    onAdd?.(normalized);
+    setVal("");
   };
   return (
     <div className="flex items-center gap-2 text-sm w-full">
@@ -19,7 +19,9 @@ export default function DocumentInput({ onAdd }) {
       </label>
       <input
         id="document-url"
-        type="url"
+        type="text"
+        inputMode="url"
+        autoComplete="url"
         value={val}
         onChange={(e) => setVal(e.target.value)}
         onKeyDown={(e) => {

--- a/src/components/LinksEditor.jsx
+++ b/src/components/LinksEditor.jsx
@@ -1,16 +1,16 @@
 import React, { useState } from "react";
 import { Link2, X, Plus } from "lucide-react";
+import { normalizeUrl } from "../utils.js";
 
 export function LinksEditor({ links = [], onAdd, onRemove }) {
   const [val, setVal] = useState("");
   const add = () => {
     const url = val.trim();
     if (!url) return;
-    try {
-      const u = new URL(url);
-      onAdd?.(u.toString());
-      setVal("");
-    } catch {}
+    const normalized = normalizeUrl(url);
+    if (!normalized) return;
+    onAdd?.(normalized);
+    setVal("");
   };
   return (
     <div className="mt-1">

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,21 @@ export const todayStr = () => new Date().toISOString().slice(0, 10);
 export const fmt = (d) => new Date(d).toISOString().slice(0, 10);
 export const clamp = (n, min, max) => Math.max(min, Math.min(max, n));
 
+const tryParseUrl = (value) => {
+  try {
+    return new URL(value).toString();
+  } catch {
+    return null;
+  }
+};
+
+export const normalizeUrl = (rawUrl) => {
+  if (typeof rawUrl !== "string") return null;
+  const candidate = rawUrl.trim();
+  if (!candidate) return null;
+  return tryParseUrl(candidate) ?? tryParseUrl(`https://${candidate}`);
+};
+
 export const rolePalette = {
   LD: "#4f46e5",
   SME: "#16a34a",

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { uid } from './utils.js';
+import { uid, normalizeUrl } from './utils.js';
 
 describe('uid', () => {
   it('returns a valid UUID v4', () => {
@@ -16,5 +16,22 @@ describe('uid', () => {
       expect(ids.has(id)).toBe(false);
       ids.add(id);
     }
+  });
+});
+
+describe('normalizeUrl', () => {
+  it('returns normalized url when protocol is present', () => {
+    const input = 'https://example.com/docs';
+    expect(normalizeUrl(input)).toBe(new URL(input).toString());
+  });
+
+  it('adds https protocol when missing', () => {
+    const input = 'www.google.com';
+    expect(normalizeUrl(input)).toBe(new URL(`https://${input}`).toString());
+  });
+
+  it('returns null for invalid urls', () => {
+    expect(normalizeUrl('not a url')).toBeNull();
+    expect(normalizeUrl('')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- add a normalizeUrl helper that adds an https prefix when needed
- use the helper in link inputs and relax browser validation so bare domains can be submitted
- cover the helper with unit tests

## Testing
- npm test *(fails: vitest not found because dependencies cannot be installed; npm install returns 403 for @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4f187908832b8e72f2824477cf6e