### PR TITLE
Add blocked status across tasks and boards

### DIFF
--- a/src/BoardView.test.jsx
+++ b/src/BoardView.test.jsx
@@ -46,6 +46,13 @@ describe('BoardView mobile status selection', () => {
     expect(onUpdate).toHaveBeenCalledWith('t1', { status: 'inprogress' });
   });
 
+  it('changes from todo to blocked', () => {
+    const onUpdate = vi.fn();
+    renderBoard('todo', onUpdate);
+    fireEvent.change(openSelect(), { target: { value: 'blocked' } });
+    expect(onUpdate).toHaveBeenCalledWith('t1', { status: 'blocked' });
+  });
+
   it('changes from inprogress to done', () => {
     const onUpdate = vi.fn();
     renderBoard('inprogress', onUpdate);
@@ -65,6 +72,13 @@ describe('BoardView mobile status selection', () => {
     renderBoard('done', onUpdate);
     fireEvent.change(openSelect(), { target: { value: 'inprogress' } });
     expect(onUpdate).toHaveBeenCalledWith('t1', { status: 'inprogress' });
+  });
+
+  it('shows blocked pill styling on board', () => {
+    const onUpdate = vi.fn();
+    renderBoard('blocked', onUpdate);
+    const trigger = screen.getByRole('button', { name: /status: blocked/i });
+    expect(trigger).toHaveClass('bg-orange-100');
   });
 
   it('updates button text after selection', async () => {
@@ -97,6 +111,12 @@ describe('BoardView mobile status selection', () => {
       target: { value: 'inprogress' },
     });
     await screen.findByRole('button', { name: /status: in progress/i });
+  });
+
+  it('renders blocked column header', () => {
+    const onUpdate = vi.fn();
+    renderBoard('todo', onUpdate);
+    expect(screen.getByText('Blocked')).toBeInTheDocument();
   });
 
   it('allows editing start date when status is todo', () => {

--- a/src/TaskCard.jsx
+++ b/src/TaskCard.jsx
@@ -16,16 +16,16 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
   const [collapsed, setCollapsed] = useState(true);
   const isMobile = useIsMobile();
   const dragProps = isMobile ? {} : dragHandlers;
-  const statusList = ['todo', 'inprogress', 'done'];
-  const statusLabel = { todo: 'To Do', inprogress: 'In Progress', done: 'Done' };
+  const statusList = ['todo', 'inprogress', 'blocked', 'done'];
+  const statusLabel = { todo: 'To Do', inprogress: 'In Progress', blocked: 'Blocked', done: 'Done' };
   const soundEnabled = useContext(SoundContext);
   const audioCtxRef = useRef(null);
   const controls = useAnimation();
-  const statusColors = { todo: '#bfdbfe', inprogress: '#fef3c7', done: '#dcfce7' };
-  useEffect(() => { controls.set({ backgroundColor: statusColors[t.status], scale: 1 }); }, []);
+  const statusColors = { todo: '#bfdbfe', inprogress: '#fef3c7', blocked: '#fed7aa', done: '#dcfce7' };
+  useEffect(() => { controls.set({ backgroundColor: statusColors[t.status] || statusColors.todo, scale: 1 }); }, []);
   useEffect(() => {
     controls.start({
-      backgroundColor: statusColors[t.status],
+      backgroundColor: statusColors[t.status] || statusColors.todo,
       scale: [1.02, 1],
       transition: { duration: 0.2 }
     });
@@ -65,6 +65,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
   }, [collapsed]);
   const statusPillClass = (status) => {
     if (status === 'done') return 'bg-emerald-100/80 text-emerald-700 border-emerald-200/80';
+    if (status === 'blocked') return 'bg-orange-100/80 text-orange-700 border-orange-200/80';
     if (status === 'inprogress') return 'bg-amber-100/80 text-amber-700 border-amber-200/80';
     return 'bg-sky-100/80 text-sky-700 border-sky-200/80';
   };
@@ -141,6 +142,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                 >
                   <option value="todo">To Do</option>
                   <option value="inprogress">In Progress</option>
+                  <option value="blocked">Blocked</option>
                   <option value="done">Done</option>
                 </select>
               ) : (
@@ -164,6 +166,7 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
               >
                 <option value="todo">To Do</option>
                 <option value="inprogress">In Progress</option>
+                <option value="blocked">Blocked</option>
                 <option value="done">Done</option>
               </select>
             )}
@@ -227,9 +230,10 @@ export default function TaskCard({ task: t, team = [], milestones = [], tasks = 
                   className={`${statusPillBase} ${statusPillClass(t.status)}`}
                   autoFocus
                 >
-                  <option value="todo">To Do</option>
-                  <option value="inprogress">In Progress</option>
-                  <option value="done">Done</option>
+        <option value="todo">To Do</option>
+        <option value="inprogress">In Progress</option>
+        <option value="blocked">Blocked</option>
+        <option value="done">Done</option>
                 </select>
               ) : (
                 <button

--- a/src/TaskCard.test.jsx
+++ b/src/TaskCard.test.jsx
@@ -152,6 +152,13 @@ describe('TaskCard', () => {
       expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { status: 'inprogress' });
     });
 
+    it('changes from todo to blocked', () => {
+      const onUpdate = vi.fn();
+      const select = renderWithStatus('todo', onUpdate);
+      fireEvent.change(select, { target: { value: 'blocked' } });
+      expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { status: 'blocked' });
+    });
+
     it('changes from inprogress to done', () => {
       const onUpdate = vi.fn();
       const select = renderWithStatus('inprogress', onUpdate);
@@ -195,6 +202,21 @@ describe('TaskCard', () => {
         target: { value: 'inprogress' },
       });
       await screen.findByRole('button', { name: /status: in progress/i });
+    });
+
+    it('shows blocked pill styling', () => {
+      const onUpdate = vi.fn();
+      render(
+        <TaskCard
+          task={{ ...sampleTask, status: 'blocked' }}
+          milestones={milestones}
+          onUpdate={onUpdate}
+          onDelete={() => {}}
+          onDuplicate={() => {}}
+        />
+      );
+      const trigger = screen.getByRole('button', { name: /status: blocked/i });
+      expect(trigger).toHaveClass('bg-orange-100/80');
     });
   });
 

--- a/src/UpcomingDeadlines.test.jsx
+++ b/src/UpcomingDeadlines.test.jsx
@@ -32,6 +32,7 @@ describe('Upcoming Deadlines window', () => {
       tasks: [
         { id: 't1', title: 'Today Task', status: 'todo', dueDate: fmt(today), assigneeId: 'u1', milestoneId: 'm1' },
         { id: 't2', title: 'Future Task', status: 'todo', dueDate: fmt(day14), assigneeId: 'u1', milestoneId: 'm2' },
+        { id: 't4', title: 'Blocked Task', status: 'blocked', dueDate: fmt(day14), assigneeId: 'u1', milestoneId: 'm2' },
         { id: 't3', title: 'Outside Task', status: 'todo', dueDate: fmt(day15), assigneeId: 'u1', milestoneId: 'm1' },
       ],
       team: [{ id: 'u1', name: 'Alice', roleType: 'LD' }],
@@ -48,6 +49,9 @@ describe('Upcoming Deadlines window', () => {
     expect(taskButton).toBeInTheDocument();
     expect(
       await screen.findByRole('button', { name: 'Future Task for Milestone 2' })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Blocked Task for Milestone 2' })
     ).toBeInTheDocument();
     expect(screen.queryByText('Outside Task')).toBeNull();
 

--- a/src/components/TaskModal.jsx
+++ b/src/components/TaskModal.jsx
@@ -10,6 +10,7 @@ import { useCompletionConfetti } from "../hooks/use-completion-confetti.js";
 
 function statusBg(status) {
   if (status === "done") return "bg-emerald-50";
+  if (status === "blocked") return "bg-orange-50";
   if (status === "inprogress") return "bg-amber-50";
   return "bg-sky-50";
 }
@@ -140,6 +141,7 @@ export default function TaskModal({ task, courseId, courses, onChangeCourse, tas
           >
             <option value="todo">To Do</option>
             <option value="inprogress">In Progress</option>
+            <option value="blocked">Blocked</option>
             <option value="done">Done</option>
           </select>
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add the blocked status option to task controls and shared board views with orange styling
- update dashboard helpers, grouping logic, and task duplication to recognise blocked work
- expand unit tests to cover the blocked status in cards, boards, and upcoming deadlines

## Testing
- npm test *(fails: vitest not found because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbdd0fc4b8832b9561dcd2497b921d