### PR TITLE
feat: surface and resolve task blocks

### DIFF
--- a/src/UpcomingDeadlines.test.jsx
+++ b/src/UpcomingDeadlines.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { UserDashboard, UPCOMING_DAYS } from './App.jsx';
 import { fmt } from './utils.js';
@@ -94,5 +94,94 @@ describe('Upcoming Deadlines window', () => {
     expect(await screen.findByText('Please provide a link to the output')).toBeInTheDocument();
     fireEvent.click(screen.getByText('No link'));
     expect(box).toBeChecked();
+  });
+
+  it('lists dashboard blocks and allows resolving them', async () => {
+    const courses = [
+      {
+        course: { id: 'c1', name: 'Course 1' },
+        milestones: [{ id: 'm1', title: 'Milestone 1' }],
+        tasks: [
+          {
+            id: 't1',
+            title: 'Task 1',
+            status: 'blocked',
+            milestoneId: 'm1',
+            blocks: [
+              {
+                id: 'b1',
+                reportedAt: '2024-01-02',
+                reportedBy: 'u1',
+                description: 'Need dataset',
+                taggedMemberIds: ['u2'],
+                resolvedAt: null,
+                resolvedBy: null,
+                resolution: '',
+              },
+              {
+                id: 'b2',
+                reportedAt: '2024-01-03',
+                reportedBy: 'u2',
+                description: 'Awaiting review',
+                taggedMemberIds: ['u1'],
+                resolvedAt: null,
+                resolvedBy: null,
+                resolution: '',
+              },
+              {
+                id: 'b3',
+                reportedAt: '2024-01-01',
+                reportedBy: 'u1',
+                description: 'Old block',
+                taggedMemberIds: [],
+                resolvedAt: '2024-01-04',
+                resolvedBy: 'u1',
+                resolution: 'Completed work',
+              },
+            ],
+          },
+        ],
+        team: [
+          { id: 'u1', name: 'Alice', roleType: 'PM' },
+          { id: 'u2', name: 'Bob', roleType: 'LD' },
+        ],
+        schedule: {},
+      },
+    ];
+    localStorage.setItem('healthPM:courses:v1', JSON.stringify(courses));
+
+    render(<UserDashboard onOpenCourse={() => {}} onBack={() => {}} initialUserId="u1" />);
+
+    const showBlocks = await screen.findByRole('button', { name: 'Show' });
+    fireEvent.click(showBlocks);
+
+    expect(await screen.findByText('Need dataset')).toBeInTheDocument();
+    expect(screen.getByText('Awaiting review')).toBeInTheDocument();
+
+    const helpSection = screen.getByText('Blocks I Can Help Address').parentElement;
+    const helpResolve = within(helpSection).getByRole('button', { name: 'Resolve' });
+    fireEvent.click(helpResolve);
+
+    const dialog = await screen.findByRole('dialog', { name: 'Resolve Block' });
+    fireEvent.change(screen.getByLabelText('Resolution notes'), {
+      target: { value: 'Provided feedback' },
+    });
+    fireEvent.change(screen.getByLabelText('Resolved by'), {
+      target: { value: 'u1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve Block' }));
+
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
+
+    expect(screen.getByText('Need dataset')).toBeInTheDocument();
+    expect(screen.getByText('No blocks are currently tagging you.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resolved (2)' }));
+    expect(await screen.findByText('Provided feedback')).toBeInTheDocument();
+
+    const stored = JSON.parse(localStorage.getItem('healthPM:courses:v1'));
+    const updated = stored[0].tasks[0].blocks.find((b) => b.id === 'b2');
+    expect(updated.resolvedAt).toBeTruthy();
+    expect(updated.resolution).toBe('Provided feedback');
   });
 });

--- a/src/blockUtils.js
+++ b/src/blockUtils.js
@@ -1,0 +1,183 @@
+const ensureArray = (value) => (Array.isArray(value) ? value : []);
+
+const toDateValue = (value) => {
+  if (!value) return 0;
+  const ts = Date.parse(value);
+  return Number.isNaN(ts) ? 0 : ts;
+};
+
+const buildMemberLookup = (courses = [], members = []) => {
+  const lookup = new Map();
+  ensureArray(members).forEach((member) => {
+    if (member && member.id && !lookup.has(member.id)) {
+      lookup.set(member.id, member);
+    }
+  });
+  ensureArray(courses).forEach((course) => {
+    ensureArray(course?.team).forEach((member) => {
+      if (member && member.id && !lookup.has(member.id)) {
+        lookup.set(member.id, member);
+      }
+    });
+  });
+  return lookup;
+};
+
+export const collectBlocks = (courses = [], members = []) => {
+  const all = [];
+  const memberLookup = buildMemberLookup(courses, members);
+
+  ensureArray(courses).forEach((course) => {
+    const courseMeta = course?.course ?? {};
+    const courseId = courseMeta.id ?? course?.id ?? '';
+    const courseName = courseMeta.name ?? 'Untitled course';
+    const courseDescription = courseMeta.description ?? '';
+    const courseCode = courseMeta.code ?? '';
+    const milestoneLookup = new Map(
+      ensureArray(course?.milestones).map((milestone) => [milestone.id, milestone])
+    );
+
+    ensureArray(course?.tasks).forEach((task) => {
+      const milestone = task?.milestoneId ? milestoneLookup.get(task.milestoneId) ?? null : null;
+      ensureArray(task?.blocks).forEach((block) => {
+        if (!block || !block.id) return;
+        const reporter = block.reportedBy ? memberLookup.get(block.reportedBy) ?? null : null;
+        const resolver = block.resolvedBy ? memberLookup.get(block.resolvedBy) ?? null : null;
+        const taggedMemberIds = Array.isArray(block.taggedMemberIds)
+          ? Array.from(new Set(block.taggedMemberIds.filter(Boolean)))
+          : [];
+        const taggedMembers = taggedMemberIds
+          .map((id) => memberLookup.get(id) ?? null)
+          .filter(Boolean);
+
+        all.push({
+          id: block.id,
+          blockId: block.id,
+          courseId,
+          course: {
+            id: courseId,
+            name: courseName,
+            description: courseDescription,
+            code: courseCode,
+          },
+          taskId: task?.id,
+          task: {
+            id: task?.id,
+            title: task?.title ?? '',
+            status: task?.status ?? '',
+          },
+          milestone: milestone
+            ? {
+                id: milestone.id,
+                title: milestone.title ?? '',
+                color: milestone.color,
+              }
+            : null,
+          reportedAt: block.reportedAt ?? '',
+          reportedAtValue: toDateValue(block.reportedAt),
+          reportedBy: block.reportedBy ?? '',
+          reporter,
+          description: block.description ?? '',
+          taggedMemberIds,
+          taggedMembers,
+          resolution: block.resolution ?? '',
+          resolvedAt: block.resolvedAt ?? null,
+          resolvedAtValue: block.resolvedAt ? toDateValue(block.resolvedAt) : 0,
+          resolvedBy: block.resolvedBy ?? '',
+          resolver,
+        });
+      });
+    });
+  });
+
+  return all;
+};
+
+export const partitionBlocks = (blocks = []) => {
+  const active = [];
+  const resolved = [];
+
+  ensureArray(blocks).forEach((entry) => {
+    if (entry?.resolvedAt) {
+      resolved.push(entry);
+    } else {
+      active.push(entry);
+    }
+  });
+
+  active.sort((a, b) => b.reportedAtValue - a.reportedAtValue);
+  resolved.sort(
+    (a, b) =>
+      b.resolvedAtValue - a.resolvedAtValue || b.reportedAtValue - a.reportedAtValue
+  );
+
+  return { active, resolved };
+};
+
+export const aggregateBlocksByCourse = (courses = [], members = []) => {
+  const all = collectBlocks(courses, members);
+  const { active, resolved } = partitionBlocks(all);
+  const byCourse = new Map();
+
+  all.forEach((entry) => {
+    if (!entry?.courseId) return;
+    if (!byCourse.has(entry.courseId)) {
+      byCourse.set(entry.courseId, {
+        course: entry.course,
+        active: [],
+        resolved: [],
+      });
+    }
+    const group = byCourse.get(entry.courseId);
+    (entry.resolvedAt ? group.resolved : group.active).push(entry);
+  });
+
+  byCourse.forEach((group) => {
+    group.active.sort((a, b) => b.reportedAtValue - a.reportedAtValue);
+    group.resolved.sort(
+      (a, b) => b.resolvedAtValue - a.resolvedAtValue || b.reportedAtValue - a.reportedAtValue
+    );
+  });
+
+  return { all, active, resolved, byCourse };
+};
+
+export const applyBlockResolution = (
+  courses = [],
+  { courseId, taskId, blockId, resolution, resolvedBy, resolvedAt }
+) => {
+  if (!courseId || !taskId || !blockId) return courses;
+  let changed = false;
+
+  const nextCourses = ensureArray(courses).map((course) => {
+    const currentId = course?.course?.id ?? course?.id;
+    if (currentId !== courseId) return course;
+
+    const nextTasks = ensureArray(course?.tasks).map((task) => {
+      if (task?.id !== taskId) return task;
+      const nextBlocks = ensureArray(task?.blocks).map((block) => {
+        if (!block || block.id !== blockId) return block;
+        changed = true;
+        return {
+          ...block,
+          resolution: resolution ?? '',
+          resolvedBy: resolvedBy ?? '',
+          resolvedAt: resolvedAt ?? '',
+        };
+      });
+      if (!changed) return task;
+      const hasActive = nextBlocks.some((block) => block && !block.resolvedAt);
+      const nextStatus = !hasActive && task?.status === 'blocked' ? 'inprogress' : task?.status;
+      return {
+        ...task,
+        blocks: nextBlocks,
+        status: nextStatus,
+      };
+    });
+
+    return changed ? { ...course, tasks: nextTasks } : course;
+  });
+
+  return changed ? nextCourses : courses;
+};
+

--- a/src/components/BlockDialog.jsx
+++ b/src/components/BlockDialog.jsx
@@ -7,32 +7,68 @@ export default function BlockDialog({
   task,
   team = [],
   reporter = null,
+  resolver = null,
+  block = null,
+  mode = "report",
   onSubmit,
+  onResolve,
   onCancel,
 }) {
+  const isResolveMode = mode === "resolve";
   const [description, setDescription] = useState("");
   const reporterIdDefault = reporter?.id || "";
   const [reporterId, setReporterId] = useState(reporterIdDefault);
   const defaultTagged = useMemo(
-    () => team.filter((member) => member.roleType === "PM").map((member) => member.id),
-    [team]
+    () =>
+      isResolveMode
+        ? Array.isArray(block?.taggedMemberIds)
+          ? Array.from(new Set(block.taggedMemberIds.filter(Boolean)))
+          : []
+        : team
+            .filter((member) => member.roleType === "PM")
+            .map((member) => member.id),
+    [team, isResolveMode, block?.taggedMemberIds]
   );
   const [taggedIds, setTaggedIds] = useState(defaultTagged);
+  const [resolution, setResolution] = useState("");
+  const resolverDefault = useMemo(() => {
+    if (block?.resolvedBy) return block.resolvedBy;
+    if (resolver?.id) return resolver.id;
+    if (reporter?.id) return reporter.id;
+    return team[0]?.id || "";
+  }, [block?.resolvedBy, resolver?.id, reporter?.id, team]);
+  const [resolverId, setResolverId] = useState(resolverDefault);
   const dialogRef = useRef(null);
   const descriptionRef = useRef(null);
+  const resolutionRef = useRef(null);
+  const teamLookup = useMemo(() => new Map(team.map((member) => [member.id, member])), [team]);
 
   useEffect(() => {
     if (!open) return;
-    setDescription("");
-    setReporterId(reporterIdDefault);
-    setTaggedIds(defaultTagged);
-  }, [open, reporterIdDefault, defaultTagged]);
+    if (isResolveMode) {
+      setResolution(block?.resolution ?? "");
+      setResolverId(block?.resolvedBy ?? resolverDefault);
+      setTaggedIds(defaultTagged);
+    } else {
+      setDescription("");
+      setReporterId(reporterIdDefault);
+      setTaggedIds(defaultTagged);
+    }
+  }, [
+    open,
+    isResolveMode,
+    block?.resolution,
+    block?.resolvedBy,
+    reporterIdDefault,
+    defaultTagged,
+    resolverDefault,
+  ]);
 
   useEffect(() => {
     if (!open) return;
     const el = dialogRef.current;
-    const desc = descriptionRef.current;
-    desc?.focus();
+    const target = isResolveMode ? resolutionRef.current : descriptionRef.current;
+    target?.focus();
     if (!el) return;
     const handleKeyDown = (event) => {
       if (event.key === "Escape") {
@@ -42,7 +78,7 @@ export default function BlockDialog({
     };
     el.addEventListener("keydown", handleKeyDown);
     return () => el.removeEventListener("keydown", handleKeyDown);
-  }, [open, onCancel]);
+  }, [open, onCancel, isResolveMode]);
 
   if (!open) return null;
 
@@ -54,21 +90,44 @@ export default function BlockDialog({
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    const trimmed = description.trim();
-    if (!trimmed || !reporterId) return;
-    const taggedMemberIds = Array.from(new Set(taggedIds));
-    const entry = {
-      id: uid(),
-      reportedAt: todayStr(),
-      reportedBy: reporterId,
-      description: trimmed,
-      taggedMemberIds,
-      resolvedAt: null,
-      resolvedBy: null,
-      resolution: "",
-    };
-    onSubmit?.(entry);
+    if (isResolveMode) {
+      const trimmedResolution = resolution.trim();
+      if (!trimmedResolution || !resolverId) return;
+      onResolve?.({
+        resolution: trimmedResolution,
+        resolvedBy: resolverId,
+        resolvedAt: todayStr(),
+      });
+    } else {
+      const trimmed = description.trim();
+      if (!trimmed || !reporterId) return;
+      const taggedMemberIds = Array.from(new Set(taggedIds));
+      const entry = {
+        id: uid(),
+        reportedAt: todayStr(),
+        reportedBy: reporterId,
+        description: trimmed,
+        taggedMemberIds,
+        resolvedAt: null,
+        resolvedBy: null,
+        resolution: "",
+      };
+      onSubmit?.(entry);
+    }
   };
+
+  const reporterMember = block?.reportedBy
+    ? teamLookup.get(block.reportedBy) ?? null
+    : reporter ?? null;
+  const resolverMember = block?.resolvedBy
+    ? teamLookup.get(block.resolvedBy) ?? null
+    : resolver ?? null;
+  const taggedMembers = Array.isArray(block?.taggedMemberIds)
+    ? block.taggedMemberIds
+        .map((id) => teamLookup.get(id))
+        .filter(Boolean)
+        .map((member) => member.name)
+    : [];
 
   return (
     <div
@@ -86,7 +145,7 @@ export default function BlockDialog({
         <div className="mb-3 flex items-start justify-between gap-2">
           <div>
             <h2 id="block-dialog-title" className="text-base font-semibold text-slate-800">
-              Mark as Blocked
+              {isResolveMode ? "Resolve Block" : "Mark as Blocked"}
             </h2>
             {task && (
               <p className="text-sm text-slate-600">
@@ -104,62 +163,126 @@ export default function BlockDialog({
           </button>
         </div>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label htmlFor="block-description" className="text-sm font-medium text-slate-700">
-              Block description
-            </label>
-            <textarea
-              id="block-description"
-              ref={descriptionRef}
-              value={description}
-              onChange={(event) => setDescription(event.target.value)}
-              rows={4}
-              className="mt-1 w-full rounded-lg border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-sm focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-              placeholder="What is blocking progress?"
-            />
-          </div>
-          <div>
-            <label htmlFor="block-reporter" className="text-sm font-medium text-slate-700">
-              Reported by
-            </label>
-            <select
-              id="block-reporter"
-              value={reporterId}
-              onChange={(event) => setReporterId(event.target.value)}
-              className="mt-1 w-full rounded-lg border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-sm focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-            >
-              <option value="">Select a reporter</option>
-              {team.map((member) => (
-                <option key={member.id} value={member.id}>
-                  {member.name} ({member.roleType})
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <div className="text-sm font-medium text-slate-700">Notify team members</div>
-            {team.length === 0 ? (
-              <p className="mt-1 text-sm text-slate-500">No team members available.</p>
-            ) : (
-              <ul className="mt-2 max-h-40 space-y-1 overflow-y-auto rounded-lg border border-slate-200 p-2">
-                {team.map((member) => (
-                  <li key={member.id}>
-                    <label className="flex items-center gap-2 text-sm text-slate-700">
-                      <input
-                        type="checkbox"
-                        checked={taggedIds.includes(member.id)}
-                        onChange={() => toggleTagged(member.id)}
-                        className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
-                      />
-                      <span className="truncate">
-                        {member.name} ({member.roleType})
-                      </span>
-                    </label>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
+          {isResolveMode ? (
+            <>
+              <div className="rounded-lg border border-emerald-100 bg-emerald-50/60 p-3 text-sm text-emerald-900">
+                <div className="font-semibold">Reported Block</div>
+                <div className="mt-1 text-emerald-900/80">
+                  {block?.description || "No description provided."}
+                </div>
+                <div className="mt-2 text-xs text-emerald-900/70">
+                  Reported by {reporterMember?.name || "Unknown"}
+                  {block?.reportedAt ? ` on ${block.reportedAt}` : ""}
+                </div>
+                {taggedMembers.length > 0 && (
+                  <div className="mt-1 text-xs text-emerald-900/70">
+                    Tagged: {taggedMembers.join(", ")}
+                  </div>
+                )}
+              </div>
+              <div>
+                <label htmlFor="block-resolution" className="text-sm font-medium text-slate-700">
+                  Resolution notes
+                </label>
+                <textarea
+                  id="block-resolution"
+                  ref={resolutionRef}
+                  value={resolution}
+                  onChange={(event) => setResolution(event.target.value)}
+                  rows={4}
+                  className="mt-1 w-full rounded-lg border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-sm focus:border-emerald-300 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                  placeholder="How was this block resolved?"
+                />
+              </div>
+              <div>
+                <label htmlFor="block-resolver" className="text-sm font-medium text-slate-700">
+                  Resolved by
+                </label>
+                <select
+                  id="block-resolver"
+                  value={resolverId}
+                  onChange={(event) => setResolverId(event.target.value)}
+                  className="mt-1 w-full rounded-lg border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-sm focus:border-emerald-300 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                >
+                  <option value="">Select a resolver</option>
+                  {team.map((member) => (
+                    <option key={member.id} value={member.id}>
+                      {member.name} ({member.roleType})
+                    </option>
+                  ))}
+                </select>
+              </div>
+              {block?.resolvedAt && block?.resolution && (
+                <div className="rounded-lg border border-emerald-100 bg-white/70 p-3 text-xs text-emerald-800">
+                  <div className="font-medium">Previous Resolution</div>
+                  <div className="mt-1">{block.resolution}</div>
+                  <div className="mt-1">
+                    Resolved by {resolverMember?.name || "Unknown"}
+                    {block.resolvedAt ? ` on ${block.resolvedAt}` : ""}
+                  </div>
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              <div>
+                <label htmlFor="block-description" className="text-sm font-medium text-slate-700">
+                  Block description
+                </label>
+                <textarea
+                  id="block-description"
+                  ref={descriptionRef}
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  rows={4}
+                  className="mt-1 w-full rounded-lg border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-sm focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                  placeholder="What is blocking progress?"
+                />
+              </div>
+              <div>
+                <label htmlFor="block-reporter" className="text-sm font-medium text-slate-700">
+                  Reported by
+                </label>
+                <select
+                  id="block-reporter"
+                  value={reporterId}
+                  onChange={(event) => setReporterId(event.target.value)}
+                  className="mt-1 w-full rounded-lg border border-slate-200 bg-white/90 px-3 py-2 text-sm shadow-sm focus:border-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                >
+                  <option value="">Select a reporter</option>
+                  {team.map((member) => (
+                    <option key={member.id} value={member.id}>
+                      {member.name} ({member.roleType})
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <div className="text-sm font-medium text-slate-700">Notify team members</div>
+                {team.length === 0 ? (
+                  <p className="mt-1 text-sm text-slate-500">No team members available.</p>
+                ) : (
+                  <ul className="mt-2 max-h-40 space-y-1 overflow-y-auto rounded-lg border border-slate-200 p-2">
+                    {team.map((member) => (
+                      <li key={member.id}>
+                        <label className="flex items-center gap-2 text-sm text-slate-700">
+                          <input
+                            type="checkbox"
+                            checked={taggedIds.includes(member.id)}
+                            onChange={() => toggleTagged(member.id)}
+                            className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                          />
+                          <span className="truncate">
+                            {member.name} ({member.roleType})
+                          </span>
+                        </label>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </>
+          )}
           <div className="flex items-center justify-end gap-2">
             <button
               type="button"
@@ -170,10 +293,14 @@ export default function BlockDialog({
             </button>
             <button
               type="submit"
-              className="glass-button-primary"
-              disabled={!description.trim() || !reporterId}
+              className={isResolveMode ? "glass-button-success" : "glass-button-primary"}
+              disabled={
+                isResolveMode
+                  ? !resolution.trim() || !resolverId
+                  : !description.trim() || !reporterId
+              }
             >
-              Add Block
+              {isResolveMode ? "Resolve Block" : "Add Block"}
             </button>
           </div>
         </form>

--- a/src/index.css
+++ b/src/index.css
@@ -79,6 +79,22 @@ body {
     box-shadow: 0 22px 38px -20px rgba(15, 23, 42, 0.72);
   }
 
+  .glass-button-success {
+    @apply inline-flex items-center justify-center gap-1.5 rounded-2xl px-4 py-2 text-sm font-semibold text-white transition-all duration-200;
+    background: linear-gradient(135deg, #0f766e, #34d399);
+    box-shadow: 0 24px 46px -24px rgba(16, 185, 129, 0.6);
+  }
+
+  .glass-button-success:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 28px 50px -22px rgba(16, 185, 129, 0.55);
+  }
+
+  .glass-button-success:active {
+    transform: translateY(1px);
+    box-shadow: 0 22px 38px -20px rgba(13, 148, 136, 0.52);
+  }
+
   .glass-icon-button {
     @apply inline-flex items-center justify-center w-9 h-9 rounded-full transition-all duration-200;
     color: #475569;


### PR DESCRIPTION
## Summary
- add shared helpers to collect task blocks with course, milestone, and member context and partition them into active versus resolved sets
- extend the block dialog to support resolving existing entries while preserving the reporting flow and styling the resolve action
- surface course and dashboard block panels with resolve handling, persistence updates, and UI coverage in the associated tests

## Testing
- npm install *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fforms)*
- npm test *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf0eed290832babad71deaaed32dc