### PR TITLE
Fix BlockDialog max height clamp

### DIFF
--- a/src/components/BlockDialog.jsx
+++ b/src/components/BlockDialog.jsx
@@ -143,7 +143,7 @@ export default function BlockDialog({
         role="dialog"
         aria-modal="true"
         aria-labelledby="block-dialog-title"
-        className="w-full max-w-xl glass-surface p-5 sm:p-6"
+        className="w-full max-w-xl max-h-[calc(100vh_-_3rem)] glass-surface p-5 sm:p-6"
         onClick={(event) => event.stopPropagation()}
       >
         <div className="mb-5 flex items-start justify-between gap-3">


### PR DESCRIPTION
## Summary
- ensure the BlockDialog dialog wrapper uses a max-height utility that Tailwind will compile by replacing the calc syntax with underscore delimiters

## Testing
- npm run build *(fails: vite executable not found because dependencies could not be installed in the environment)*


------
https://chatgpt.com/codex/tasks/task_e_68cc6fc35bb0832b80e559e53f465fdc