### PR TITLE
Ensure PM views reset scroll position

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4374,6 +4374,15 @@ export default function PMApp() {
   };
   const onBack = () => { setView(prevView); setPrevView("hub"); setCurrentCourseId(null); };
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+    if (typeof document !== "undefined") {
+      if (document.documentElement) document.documentElement.scrollTop = 0;
+      if (document.body) document.body.scrollTop = 0;
+    }
+  }, [view, currentCourseId, currentUserId]);
+
   let content = null;
   if (view === "hub") {
     content = (


### PR DESCRIPTION
## Summary
- add a scroll-resetting effect in PMApp when switching between hub, course, and user views

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc7237a088832bb8aacbc2a7911a0e