### PR TITLE
Ensure PM views reset scroll position

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4374,6 +4374,26 @@ export default function PMApp() {
   };
   const onBack = () => { setView(prevView); setPrevView("hub"); setCurrentCourseId(null); };
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const { scrollTo } = window;
+    if (typeof scrollTo === "function") {
+      try {
+        scrollTo({ top: 0, left: 0, behavior: "auto" });
+      } catch {
+        scrollTo(0, 0);
+      }
+    }
+
+    if (typeof document !== "undefined") {
+      const { documentElement, body, scrollingElement } = document;
+      if (scrollingElement) scrollingElement.scrollTop = 0;
+      if (documentElement) documentElement.scrollTop = 0;
+      if (body) body.scrollTop = 0;
+    }
+  }, [view, currentCourseId, currentUserId]);
+
   let content = null;
   if (view === "hub") {
     content = (


### PR DESCRIPTION
## Summary
- guard the scroll-reset effect against browsers that do not support the options-object form of `window.scrollTo`
- explicitly reset `document.scrollingElement` along with the body and document element to guarantee the viewport returns to the top

## Testing
- `npm test -- --runInBand` *(fails: vitest binary missing because dependencies cannot be installed in this environment)*
- `npm install` *(fails: registry returned HTTP 403, preventing dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7237a088832bb8aacbc2a7911a0e