### PR TITLE
Fix scroll reset effect logic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4376,10 +4376,24 @@ export default function PMApp() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+
+    const { scrollTo } = window;
+
+    if (typeof scrollTo === "function") {
+      try {
+        scrollTo({ top: 0, left: 0, behavior: "auto" });
+      } catch {
+        scrollTo(0, 0);
+      }
+    } else {
+      window.scrollTo(0, 0);
+    }
+
     if (typeof document !== "undefined") {
-      if (document.documentElement) document.documentElement.scrollTop = 0;
-      if (document.body) document.body.scrollTop = 0;
+      const { scrollingElement, documentElement, body } = document;
+      if (scrollingElement) scrollingElement.scrollTop = 0;
+      if (documentElement) documentElement.scrollTop = 0;
+      if (body) body.scrollTop = 0;
     }
   }, [view, currentCourseId, currentUserId]);
 


### PR DESCRIPTION
## Summary
- update the PMApp scroll reset effect to destructure `scrollTo` from `window` and fall back safely when the options signature is unsupported
- preserve document-level scroll resets for `scrollingElement`, `documentElement`, and `body` while keeping the SSR window guard

## Testing
- npm test *(fails: `vitest` not found because npm install cannot access `@tailwindcss/forms` due to 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cc79cc8694832b809095b622755919