### PR TITLE
Improve BlockDialog layout and overlay

### DIFF
--- a/src/components/BlockDialog.jsx
+++ b/src/components/BlockDialog.jsx
@@ -135,7 +135,7 @@ export default function BlockDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/55 px-4 py-6"
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-900/60 px-4 py-10 backdrop-blur-sm backdrop-saturate-150 sm:items-center sm:py-6"
       onClick={() => onCancel?.()}
     >
       <div
@@ -143,7 +143,7 @@ export default function BlockDialog({
         role="dialog"
         aria-modal="true"
         aria-labelledby="block-dialog-title"
-        className="w-full max-w-xl max-h-[calc(100vh_-_3rem)] glass-surface p-5 sm:p-6"
+        className="w-full max-w-xl max-h-[calc(100vh_-_3rem)] overflow-y-auto glass-surface p-5 sm:overflow-y-visible sm:p-6"
         onClick={(event) => event.stopPropagation()}
       >
         <div className="mb-5 flex items-start justify-between gap-3">


### PR DESCRIPTION
## Summary
- allow the BlockDialog overlay to scroll, align toward the top on small screens, and add a blurred, saturated backdrop that better matches the glass aesthetic
- let the frosted BlockDialog panel scroll within its viewport height cap so long content stays inside the rounded surface
- verified the modal still pulls in the global Tailwind layer through the existing `src/index.css` import in `src/main.jsx`

## Testing
- `npm run build` *(fails: vite not found before installing dependencies)*
- `npm install` *(fails: npm registry access restricted in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc74abd644832bb620c166c90bc377