### PR TITLE
Align notify list class ordering

### DIFF
--- a/src/components/BlockDialog.jsx
+++ b/src/components/BlockDialog.jsx
@@ -279,7 +279,7 @@ export default function BlockDialog({
                   {team.length === 0 ? (
                     <p className="text-sm text-slate-500/80">No team members available.</p>
                   ) : (
-                    <ul className="max-h-48 overflow-y-auto glass-card p-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    <ul className="glass-card max-h-48 overflow-y-auto p-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
                       {team.map((member) => (
                         <li key={member.id} className="min-w-0">
                           <label className="flex items-center gap-3 rounded-2xl border border-white/60 bg-white/45 px-3 py-2 text-sm text-slate-800 shadow-[0_18px_32px_-20px_rgba(15,23,42,0.35)] backdrop-blur">


### PR DESCRIPTION
## Summary
- align the "Notify team members" list classes in the report flow with the ordering used on main to keep responsive grid and overflow behavior consistent

## Testing
- npm test *(fails: vitest binary unavailable without installing dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9d4eda5c832b85a7a5a20a72315a