### PR TITLE
Refine block dialog member list layout

### DIFF
--- a/src/components/BlockDialog.jsx
+++ b/src/components/BlockDialog.jsx
@@ -153,7 +153,7 @@ export default function BlockDialog({
         className="w-full max-w-xl glass-surface overflow-hidden rounded-[28px] shadow-[0_38px_90px_-42px_rgba(15,23,42,0.58)]"
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="max-h-[calc(100vh_-_3rem)] overflow-y-auto p-5 sm:overflow-y-visible sm:p-6">
+        <div className="max-h-[calc(100vh_-_3rem)] overflow-y-auto p-5 sm:max-h-none sm:overflow-y-visible sm:p-6">
           <div className="mb-5 flex items-start justify-between gap-3">
             <div className="min-w-0 space-y-1">
               <h2
@@ -317,17 +317,17 @@ export default function BlockDialog({
                         </div>
                       </div>
                       {showTagPicker && (
-                        <ul className="glass-card p-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                        <ul className="glass-card grid grid-cols-1 gap-2 p-3 sm:grid-cols-2">
                           {team.map((member) => (
                             <li key={member.id} className="min-w-0">
-                              <label className="flex items-center gap-3 rounded-2xl border border-white/60 bg-white/45 px-3 py-2 text-sm text-slate-800 shadow-[0_18px_32px_-20px_rgba(15,23,42,0.35)] backdrop-blur">
+                              <label className="flex items-start gap-3 rounded-2xl border border-white/60 bg-white/45 px-3 py-2 text-sm text-slate-800 shadow-[0_18px_32px_-20px_rgba(15,23,42,0.35)] backdrop-blur">
                                 <input
                                   type="checkbox"
                                   checked={taggedIds.includes(member.id)}
                                   onChange={() => toggleTagged(member.id)}
                                   className="h-4 w-4 rounded border-white/70 bg-white/70 text-indigo-500 focus:ring-indigo-400/80 focus:ring-offset-0"
                                 />
-                                <span className="truncate">
+                                <span className="flex-1 break-words text-left leading-snug">
                                   {member.name} ({member.roleType})
                                 </span>
                               </label>


### PR DESCRIPTION
## Summary
- remove the desktop max-height restriction from the block dialog body to eliminate the lingering scroll bar
- allow member names in the notify list to wrap so full names stay visible while preserving the requested list styling

## Testing
- npm test -- --run *(fails: vitest missing before install)*
- npm install *(fails: registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb937c414832b832f65477ecfcbed