### PR TITLE
Fix BlockDialog overlay scrolling

### DIFF
--- a/src/components/BlockDialog.jsx
+++ b/src/components/BlockDialog.jsx
@@ -142,7 +142,7 @@ export default function BlockDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-900/60 px-4 py-10 backdrop-blur-sm backdrop-saturate-150 sm:items-center sm:py-6"
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-hidden bg-slate-900/60 px-4 py-10 backdrop-blur-sm backdrop-saturate-150 sm:items-center sm:py-6"
       onClick={() => onCancel?.()}
     >
       <div
@@ -153,7 +153,7 @@ export default function BlockDialog({
         className="w-full max-w-xl glass-surface overflow-hidden rounded-[28px] shadow-[0_38px_90px_-42px_rgba(15,23,42,0.58)]"
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="max-h-[calc(100vh_-_3rem)] overflow-y-auto p-5 sm:overflow-y-visible sm:p-6">
+        <div className="max-h-[calc(100vh_-_5rem)] overflow-y-auto p-5 sm:max-h-[calc(100vh_-_3rem)] sm:overflow-y-visible sm:p-6">
           <div className="mb-5 flex items-start justify-between gap-3">
             <div className="min-w-0 space-y-1">
               <h2


### PR DESCRIPTION
## Summary
- prevent the BlockDialog overlay from adding a page scrollbar by hiding overflow on the fixed wrapper
- keep the dialog content scrollable on compact screens by matching its max-height to the overlay padding

## Testing
- npm run build *(fails: unable to install dependencies from npm registry due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc75854bc832b860b22936b814f25