### PR TITLE
Remove overlay backdrop from block dialog

### DIFF
--- a/src/components/BlockDialog.jsx
+++ b/src/components/BlockDialog.jsx
@@ -142,7 +142,7 @@ export default function BlockDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-hidden bg-slate-900/60 px-4 py-10 backdrop-blur-sm backdrop-saturate-150 sm:items-center sm:py-6"
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-hidden px-4 py-10 sm:items-center sm:py-6"
       onClick={() => onCancel?.()}
     >
       <div


### PR DESCRIPTION
## Summary
- remove the translucent grey backdrop tint from the block dialog wrapper so the modal retains positioning without the overlay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccca36e1ec832ba80451162478fb71