### PR TITLE
Adjust user board task cards layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3200,6 +3200,7 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
                                   },
                                 }}
                                 reporter={user || null}
+                                variant="user-board"
                               />
                             );
                           })}

--- a/src/TaskCard.test.jsx
+++ b/src/TaskCard.test.jsx
@@ -86,6 +86,34 @@ describe('TaskCard', () => {
     expect(onUpdate).toHaveBeenCalledWith(sampleTask.id, { milestoneId: 'm2' });
   });
 
+  it('renders course summary layout for user board variant', () => {
+    render(
+      <TaskCard
+        task={{
+          ...sampleTask,
+          courseName: 'History 101',
+          milestoneName: 'Module 1',
+          dueDate: '2024-01-10',
+          links: ['https://example.com/doc'],
+        }}
+        milestones={milestones}
+        onUpdate={() => {}}
+        onDelete={() => {}}
+        onDuplicate={() => {}}
+        variant="user-board"
+      />
+    );
+
+    expect(screen.getByText('History 101')).toBeInTheDocument();
+    expect(screen.getByText('Milestone')).toBeInTheDocument();
+    expect(screen.getByText('Module 1')).toBeInTheDocument();
+    expect(screen.getByText('2024-01-10')).toBeInTheDocument();
+    expect(screen.getByText('Documents')).toBeInTheDocument();
+    expect(screen.getByText('example.com')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Status')).toBeNull();
+    expect(screen.queryByLabelText('Assignee')).toBeNull();
+  });
+
   it('updates assignee while collapsed', () => {
     const onUpdate = vi.fn();
     const team = [


### PR DESCRIPTION
## Summary
- add a `user-board` variant to `TaskCard` so collapsed cards emphasize course, milestone, task title, details, and documents without status or assignee controls
- wire the user dashboard board view to render task cards with the new variant so collapsed cards follow the requested information order
- extend the task card tests to cover the new layout and ensure status/assignee controls stay hidden for the user board variant

## Testing
- npm test -- TaskCard *(fails: `vitest` binary unavailable and dependency install blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd2abdec8832b915ee9266b5bc663