### PR TITLE
Fix course history collection reference

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -208,7 +208,7 @@ const saveCoursesRemote = async (arr) => {
 };
 
 const COURSE_HISTORY_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
-const courseHistoryCollectionRef = collection(db, 'app', 'courseHistory');
+const courseHistoryCollectionRef = collection(db, 'courseHistory');
 
 const toMillis = (value, fallback) => {
   if (value && typeof value.toMillis === "function") return value.toMillis();


### PR DESCRIPTION
## Summary
- fix the Firestore course history collection path so it points to a top-level collection

## Testing
- npm test -- --run *(fails: vitest not found before dependencies are installed)*
- npm install *(fails: 403 Forbidden when downloading @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68d108d4ed4c832b81a3878fb32e710b