### PR TITLE
Allow course history writes in Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -29,6 +29,10 @@ service cloud.firestore {
       }
     }
 
+    match /courseHistory/{entryId} {
+      allow read, write: if hasCorrectPassword();
+    }
+
     match /meta/{docId} {
       allow read: if isSignedIn();
       allow create, update: if isSignedIn() && hasRole(request.auth.uid,'pc');


### PR DESCRIPTION
## Summary
- allow read/write access to the courseHistory collection for clients with the shared password guard

## Testing
- unable to run firebase emulator rules deployment due to missing firebase CLI in offline environment

------
https://chatgpt.com/codex/tasks/task_e_68d10af27518832b80c2ad1332a8fcc5