### PR TITLE
Relax course history guard

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -29,6 +29,13 @@ service cloud.firestore {
       }
     }
 
+    // Course history entries are managed exclusively by the client app and do
+    // not include the password sentinel that guards the course data. Mirror the
+    // open access granted to other client-managed docs so these writes succeed.
+    match /courseHistory/{entryId} {
+      allow read, write: if true;
+    }
+
     match /meta/{docId} {
       allow read: if isSignedIn();
       allow create, update: if isSignedIn() && hasRole(request.auth.uid,'pc');


### PR DESCRIPTION
## Summary
- allow the courseHistory collection to be read and written by the client app without the password sentinel because these documents are managed exclusively by the UI

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d10af27518832b80c2ad1332a8fcc5