### PR TITLE
Add password sentinel to course history writes

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -30,6 +30,7 @@ service cloud.firestore {
     }
 
     match /courseHistory/{entryId} {
+      // History entries should also require the shared password sentinel.
       allow read, write: if hasCorrectPassword();
     }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -208,6 +208,7 @@ const saveCoursesRemote = async (arr) => {
 };
 
 const COURSE_HISTORY_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const FIRESTORE_PASSWORD_SENTINEL = "passthesalt";
 const courseHistoryCollectionRef = collection(db, 'courseHistory');
 
 const toMillis = (value, fallback) => {
@@ -222,6 +223,7 @@ const recordCourseHistoryEntry = async ({ courseId, course, action = 'delete', p
     const createdAtMs = Date.now();
     const expiresAtTs = Timestamp.fromMillis(createdAtMs + COURSE_HISTORY_RETENTION_MS);
     const payload = {
+      password: FIRESTORE_PASSWORD_SENTINEL,
       courseId,
       course,
       action,


### PR DESCRIPTION
## Summary
- include the shared password sentinel when recording course history entries so writes satisfy the security rules
- document that the course history collection requires the password sentinel in Firestore rules

## Testing
- npm install *(fails: 403 Forbidden when downloading @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68d11af318a4832b9368139fea23402b