### PR TITLE
Restore courseHistory rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -29,8 +29,8 @@ service cloud.firestore {
       }
     }
 
+    // History entries should also require the shared password sentinel.
     match /courseHistory/{entryId} {
-      // History entries should also require the shared password sentinel.
       allow read, write: if hasCorrectPassword();
     }
 


### PR DESCRIPTION
## Summary
- document the course history rules to highlight that they require the shared password sentinel

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d141ba40a4832b92e66e0f5fc595bd