### PR TITLE
Restrict course history query to sentinel password

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,8 @@
 {
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
   "hosting": {
     "public": "dist",
     "ignore": [

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,13 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "courseHistory",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "password", "order": "ASCENDING" },
+        { "fieldPath": "expiresAt", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -251,6 +251,7 @@ const loadCourseHistoryEntries = async () => {
     const now = Date.now();
     const q = query(
       courseHistoryCollectionRef,
+      where('password', '==', FIRESTORE_PASSWORD_SENTINEL),
       where('expiresAt', '>', Timestamp.fromMillis(now)),
       orderBy('expiresAt', 'asc'),
       limit(50)


### PR DESCRIPTION
## Summary
- filter course history queries by the shared password sentinel before applying the expiresAt window
- declare the required composite index and reference it from firebase.json so the query can run without permission errors

## Testing
- `npm test` *(fails: vitest command not found because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d148e52d78832ba651887e335da7be