### PR TITLE
Filter course history queries by password sentinel

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,13 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "courseHistory",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "password", "order": "ASCENDING" },
+        { "fieldPath": "expiresAt", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -29,8 +29,8 @@ service cloud.firestore {
       }
     }
 
+    // History entries should also require the shared password sentinel.
     match /courseHistory/{entryId} {
-      // History entries should also require the shared password sentinel.
       allow read, write: if hasCorrectPassword();
     }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -251,8 +251,8 @@ const loadCourseHistoryEntries = async () => {
     const now = Date.now();
     const q = query(
       courseHistoryCollectionRef,
-      where('expiresAt', '>', Timestamp.fromMillis(now)),
-      orderBy('expiresAt', 'asc'),
+      where('password', '==', FIRESTORE_PASSWORD_SENTINEL),
+      orderBy('createdAt', 'desc'),
       limit(50)
     );
     const snapshot = await getDocs(q);
@@ -273,7 +273,8 @@ const loadCourseHistoryEntries = async () => {
     });
     rows.sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
     return rows;
-  } catch {
+  } catch (error) {
+    console.warn('Failed to load course history entries', error);
     return [];
   }
 };


### PR DESCRIPTION
## Summary
- filter the course history Firestore query by the shared password sentinel to avoid permission-denied batches from legacy documents
- define the composite Firestore index combining the password equality filter with the expiresAt ordering
- load recent course history entries by createdAt while logging query failures so the dialog shows stored entries even without the composite index

## Testing
- `npm test -- --run` *(fails: vitest binary unavailable because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d141ba40a4832b92e66e0f5fc595bd