### PR TITLE
Adjust course history query to keep newest entries

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,7 @@ import {
   query,
   where,
   orderBy,
-  limit,
+  limitToLast,
   serverTimestamp,
   Timestamp,
 } from "firebase/firestore";
@@ -255,7 +255,7 @@ const loadCourseHistoryEntries = async () => {
       where('password', '==', FIRESTORE_PASSWORD_SENTINEL),
       where('expiresAt', '>', nowTimestamp),
       orderBy('expiresAt', 'asc'),
-      limit(50)
+      limitToLast(50)
     );
     const snapshot = await getDocs(q);
     const rows = [];


### PR DESCRIPTION
## Summary
- ensure the course history query retains the newest non-expired entries by using `limitToLast`

## Testing
- npm test -- --run *(fails: vitest not found because dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ee5bc39c832bb8a155cc03a5780d