### PR TITLE
Adjust course history query to include legacy entries

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,7 @@ import {
   query,
   where,
   orderBy,
-  limitToLast,
+  limit,
   serverTimestamp,
   Timestamp,
 } from "firebase/firestore";
@@ -249,13 +249,11 @@ const recordCourseHistoryEntry = async ({ courseId, course, action = 'delete', p
 const loadCourseHistoryEntries = async () => {
   try {
     const now = Date.now();
-    const nowTimestamp = Timestamp.fromMillis(now);
     const q = query(
       courseHistoryCollectionRef,
       where('password', '==', FIRESTORE_PASSWORD_SENTINEL),
-      where('expiresAt', '>', nowTimestamp),
-      orderBy('expiresAt', 'asc'),
-      limitToLast(50)
+      orderBy('createdAt', 'desc'),
+      limit(50)
     );
     const snapshot = await getDocs(q);
     const rows = [];


### PR DESCRIPTION
## Summary
- update `loadCourseHistoryEntries` to drop the `expiresAt` filter and instead fetch recent history records ordered by creation time
- keep converting timestamp fields so downstream pruning still removes expired history entries

## Testing
- npm test *(fails: `vitest` is not installed and npm install is blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d1fb0c78b4832b987d3eac2abee03b