### PR TITLE
Add Firestore composite index for course history query

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,14 @@
         { "fieldPath": "password", "order": "ASCENDING" },
         { "fieldPath": "expiresAt", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "courseHistory",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "password", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- add a composite index entry for the courseHistory collection to cover password equality and createdAt descending order to support the application query

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d20cd56c74832ba3054374f0cceb68