### PR TITLE
Handle Firestore errors when loading course history

### DIFF
--- a/src/CoursesHub.test.jsx
+++ b/src/CoursesHub.test.jsx
@@ -238,5 +238,17 @@ describe('CoursesHub undo functionality', () => {
     expect(stored.map((c) => c.course.name)).toEqual(['Course 1', 'Course 2']);
     expect(addDoc).toHaveBeenCalled();
   });
+
+  it('surfaces errors when course history fetching fails', async () => {
+    getDocs.mockRejectedValueOnce(new Error('firestore unavailable'));
+
+    renderHub();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Version history/i }));
+
+    const errorMessage = await screen.findByText(/Failed to load course history/i);
+    expect(errorMessage).toBeInTheDocument();
+    expect(errorMessage.textContent).toContain('firestore unavailable');
+  });
 });
 


### PR DESCRIPTION
## Summary
- log Firestore errors when loading course history entries instead of returning an empty list
- surface course history loading errors in the CoursesHub modal UI
- add a regression test that verifies the error message appears when getDocs rejects

## Testing
- npm test -- --run *(fails: vitest not found because dependencies are not installed)*
- npm install *(fails: registry returned 403 for @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68d20fd20a10832b93b4d58285b4530a