### PR TITLE
Adjust course history query ordering

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,7 @@ import {
   query,
   where,
   orderBy,
-  limit,
+  limitToLast,
   serverTimestamp,
   Timestamp,
 } from "firebase/firestore";
@@ -253,8 +253,10 @@ const loadCourseHistoryEntries = async () => {
       query(
         courseHistoryCollectionRef,
         where('password', '==', FIRESTORE_PASSWORD_SENTINEL),
+        where('expiresAt', '>=', Timestamp.fromMillis(now)),
+        orderBy('expiresAt', 'asc'),
         orderBy('createdAt', 'desc'),
-        limit(50)
+        limitToLast(50)
       )
     );
     const rows = snapshot.docs


### PR DESCRIPTION
## Summary
- filter course history records by expiry timestamp and order by expiresAt asc for Firestore inequality support
- use limitToLast to retain the newest entries while still applying client-side createdAt sorting

## Testing
- `npm install` *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fforms)*
- `npm test` *(fails: sh: 1: vitest: not found; dependent on npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68d2161ec8c0832b8e7c3622286d5d5b