### PR TITLE
Persist course history fallbacks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ npm test
 
 Vitest and React Testing Library power the test suite.
 
+## Course History Resilience
+
+When a course is deleted, the app now stages a copy of that deletion event in `localStorage` before it is sent to Firestore. If the remote write fails (for example, due to a lost connection), the backup entry is merged into the history dialog on the next load so the deletion still appears in the version history. Once Firestore confirms the change, the local cache is automatically cleaned up.
+
 ## Milestone Templates
 
 The app now includes a library of reusable milestone templates. Selecting a template when adding a milestone will clone the milestone and its pre-defined tasks. You can also save any existing milestone as a new template.

--- a/src/courseHistory.test.js
+++ b/src/courseHistory.test.js
@@ -1,0 +1,151 @@
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+import { loadCourseHistoryEntries } from './App.jsx';
+
+const COURSE_HISTORY_KEY = 'healthPM:courseHistory:v1';
+
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    getItem: (key) => (key in store ? store[key] : null),
+    setItem: (key, value) => {
+      store[key] = String(value);
+    },
+    removeItem: (key) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+vi.stubGlobal('localStorage', localStorageMock);
+
+vi.mock('./firebase.js', () => ({ db: {} }));
+
+const getDocsMock = vi.fn();
+
+vi.mock('firebase/firestore', () => ({
+  getDoc: vi.fn().mockResolvedValue({ exists: () => false }),
+  setDoc: vi.fn().mockResolvedValue(),
+  doc: vi.fn(),
+  collection: vi.fn(() => ({})),
+  addDoc: vi.fn(),
+  getDocs: (...args) => getDocsMock(...args),
+  deleteDoc: vi.fn(),
+  writeBatch: vi.fn(() => ({ delete: vi.fn(), commit: vi.fn().mockResolvedValue() })),
+  query: vi.fn((...args) => args),
+  where: vi.fn(() => ({})),
+  orderBy: vi.fn(() => ({})),
+  limit: vi.fn(() => ({})),
+  serverTimestamp: vi.fn(),
+}));
+
+const makeRemovedCourse = (id, name) => ({
+  id,
+  course: { id, name },
+  tasks: [],
+  milestones: [],
+  schedule: { workweek: [1, 2, 3, 4, 5], holidays: [] },
+});
+
+const readStoredHistory = () => {
+  const raw = localStorage.getItem(COURSE_HISTORY_KEY);
+  return raw ? JSON.parse(raw) : [];
+};
+
+describe('loadCourseHistoryEntries local fallbacks', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    getDocsMock.mockReset();
+  });
+
+  it('returns locally cached deletions when Firestore fails', async () => {
+    const removedCourse = makeRemovedCourse('course-1', 'Course One');
+    const fallbackEntry = {
+      id: 'local-1',
+      courseId: 'course-1',
+      course: removedCourse,
+      action: 'delete',
+      position: 0,
+      createdAt: 1_000,
+    };
+    localStorage.setItem(COURSE_HISTORY_KEY, JSON.stringify([fallbackEntry]));
+    getDocsMock.mockRejectedValue(new Error('firestore down'));
+
+    const entries = await loadCourseHistoryEntries();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ id: 'local-1', courseId: 'course-1', action: 'delete' });
+    expect(entries[0].course.course.name).toBe('Course One');
+    expect(readStoredHistory()).toHaveLength(1);
+  });
+
+  it('removes duplicate cached entries when remote data succeeds', async () => {
+    const removedCourse = makeRemovedCourse('course-1', 'Course One');
+    const fallbackEntry = {
+      id: 'remote-1',
+      courseId: 'course-1',
+      course: removedCourse,
+      action: 'delete',
+      position: 0,
+      createdAt: 1_000,
+    };
+    localStorage.setItem(COURSE_HISTORY_KEY, JSON.stringify([fallbackEntry]));
+    getDocsMock.mockResolvedValue({
+      docs: [
+        {
+          id: 'remote-1',
+          data: () => ({
+            password: 'passthesalt',
+            courseId: 'course-1',
+            course: removedCourse,
+            action: 'delete',
+            position: 0,
+            createdAt: { toMillis: () => 2_000 },
+          }),
+        },
+      ],
+    });
+
+    const entries = await loadCourseHistoryEntries();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe('remote-1');
+    expect(readStoredHistory()).toEqual([]);
+  });
+
+  it('merges cached fallbacks with remote history', async () => {
+    const removedCourse = makeRemovedCourse('course-1', 'Course One');
+    const fallbackEntry = {
+      id: 'local-2',
+      courseId: 'course-1',
+      course: removedCourse,
+      action: 'delete',
+      position: 1,
+      createdAt: 500,
+    };
+    localStorage.setItem(COURSE_HISTORY_KEY, JSON.stringify([fallbackEntry]));
+    getDocsMock.mockResolvedValue({
+      docs: [
+        {
+          id: 'remote-2',
+          data: () => ({
+            password: 'passthesalt',
+            courseId: 'course-1',
+            course: removedCourse,
+            action: 'delete',
+            position: 0,
+            createdAt: { toMillis: () => 2_000 },
+          }),
+        },
+      ],
+    });
+
+    const entries = await loadCourseHistoryEntries();
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.id)).toEqual(['remote-2', 'local-2']);
+    expect(readStoredHistory().map((entry) => entry.id)).toEqual(['local-2']);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable helpers for sanitizing and storing course history fallbacks in localStorage
- merge remote and cached history entries so deletions persist across reloads even if Firestore fails
- document the offline history flow and cover it with Vitest scenarios that simulate Firestore outages

## Testing
- npm test *(fails: vitest binary missing because npm install is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d234c34124832bb4cb6095686355b0