### PR TITLE
Add status sorting option to course task list

### DIFF
--- a/src/components/TaskChecklist.jsx
+++ b/src/components/TaskChecklist.jsx
@@ -1,11 +1,68 @@
 import React, { useMemo } from "react";
 import { useCompletionConfetti } from "../hooks/use-completion-confetti.js";
 
-export default function TaskChecklist({ tasks, team, milestones, onUpdate, onEdit }) {
+const STATUS_LABELS = {
+  todo: "To Do",
+  inprogress: "In Progress",
+  blocked: "Blocked",
+  skip: "Skipped",
+  done: "Done",
+};
+
+const STATUS_BADGE_TONES = {
+  todo: "bg-slate-100/80 text-slate-600 border-white/60",
+  inprogress: "bg-indigo-100/80 text-indigo-600 border-indigo-200/80",
+  blocked: "bg-rose-100/80 text-rose-600 border-rose-200/80",
+  skip: "bg-amber-100/80 text-amber-700 border-amber-200/80",
+  done: "bg-emerald-100/80 text-emerald-700 border-emerald-200/80",
+};
+
+const DEFAULT_STATUS_BADGE = "bg-slate-100/80 text-slate-600 border-white/60";
+const STATUS_SORT_ORDER = ["inprogress", "blocked", "todo", "skip"];
+
+export default function TaskChecklist({
+  tasks,
+  team,
+  milestones,
+  onUpdate,
+  onEdit,
+  statusPriority = null,
+  sortMode = "dueDate",
+}) {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const todayKey = today.toDateString();
   const { fireOnDone } = useCompletionConfetti();
+  const isTaskOverdue = (task) => {
+    if (!task.dueDate) return false;
+    const due = new Date(task.dueDate);
+    due.setHours(0, 0, 0, 0);
+    return due < today;
+  };
+  const isPriorityTask = (task) => {
+    if (!statusPriority) return false;
+    if (statusPriority === "overdue") {
+      return isTaskOverdue(task);
+    }
+    return task.status === statusPriority;
+  };
+  const sortTasks = (items) =>
+    [...items].sort((a, b) => {
+      const pa = isPriorityTask(a) ? 0 : 1;
+      const pb = isPriorityTask(b) ? 0 : 1;
+      if (pa !== pb) return pa - pb;
+      const da = a.dueDate ? new Date(a.dueDate).getTime() : Number.POSITIVE_INFINITY;
+      const db = b.dueDate ? new Date(b.dueDate).getTime() : Number.POSITIVE_INFINITY;
+      if (da !== db) return da - db;
+      return (a.title || "").localeCompare(b.title || "", undefined, { sensitivity: "base" });
+    });
+
+  const formatDate = (value) =>
+    new Date(value).toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "numeric",
+      day: "numeric",
+    });
   const { activeGroups, doneTasks } = useMemo(() => {
     const upcoming = [];
     const completed = [];
@@ -16,16 +73,77 @@ export default function TaskChecklist({ tasks, team, milestones, onUpdate, onEdi
         upcoming.push(task);
       }
     }
-    const map = upcoming.reduce((acc, t) => {
-      const key = t.dueDate || "none";
-      (acc[key] ||= []).push(t);
-      return acc;
-    }, {});
-    const activeGroups = Object.entries(map).sort(([a], [b]) => {
-      if (a === "none") return 1;
-      if (b === "none") return -1;
-      return new Date(a) - new Date(b);
-    });
+    let groups;
+    if (sortMode === "status") {
+      const overdueItems = [];
+      const pending = [];
+      for (const item of upcoming) {
+        if (isTaskOverdue(item)) {
+          overdueItems.push(item);
+        } else {
+          pending.push(item);
+        }
+      }
+      const statusBuckets = pending.reduce((acc, task) => {
+        const key = task.status || "unknown";
+        (acc[key] ||= []).push(task);
+        return acc;
+      }, {});
+      const baseOrder = STATUS_SORT_ORDER.filter((key) => statusBuckets[key]?.length);
+      const extraKeys = Object.keys(statusBuckets)
+        .filter((key) => !STATUS_SORT_ORDER.includes(key))
+        .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
+      let order = [...baseOrder, ...extraKeys];
+      if (statusPriority && statusPriority !== "overdue") {
+        order = [statusPriority, ...order.filter((key) => key !== statusPriority)];
+      }
+      groups = [];
+      if (overdueItems.length > 0) {
+        const sortedOverdue = sortTasks(overdueItems);
+        groups.push({
+          id: "status:overdue",
+          heading: "Overdue",
+          items: sortedOverdue,
+          hasPriority: statusPriority === "overdue" || sortedOverdue.some(isPriorityTask),
+        });
+      }
+      for (const key of order) {
+        const bucket = statusBuckets[key];
+        if (!bucket || bucket.length === 0) continue;
+        const sortedItems = sortTasks(bucket);
+        groups.push({
+          id: `status:${key}`,
+          heading: STATUS_LABELS[key] || (key === "unknown" ? "Other" : key),
+          items: sortedItems,
+          hasPriority: statusPriority === key && sortedItems.length > 0,
+        });
+      }
+    } else {
+      const map = upcoming.reduce((acc, t) => {
+        const key = t.dueDate || "none";
+        (acc[key] ||= []).push(t);
+        return acc;
+      }, {});
+      groups = Object.entries(map).map(([date, items]) => {
+        const sortedItems = sortTasks(items);
+        const hasPriority = statusPriority ? sortedItems.some(isPriorityTask) : false;
+        return {
+          id: `due:${date}`,
+          heading: date === "none" ? "No due date" : formatDate(date),
+          items: sortedItems,
+          hasPriority,
+          date,
+        };
+      });
+      groups.sort((a, b) => {
+        if (statusPriority && a.hasPriority !== b.hasPriority) {
+          return a.hasPriority ? -1 : 1;
+        }
+        if (a.date === "none") return b.date === "none" ? 0 : 1;
+        if (b.date === "none") return -1;
+        return new Date(a.date) - new Date(b.date);
+      });
+    }
     const doneTasks = completed.sort((a, b) => {
       if (a.completedDate && b.completedDate) {
         return new Date(b.completedDate) - new Date(a.completedDate);
@@ -34,25 +152,16 @@ export default function TaskChecklist({ tasks, team, milestones, onUpdate, onEdi
       if (b.completedDate) return 1;
       return 0;
     });
-    return { activeGroups, doneTasks };
-  }, [tasks]);
-
-  const formatDate = (value) =>
-    new Date(value).toLocaleDateString(undefined, {
-      weekday: "short",
-      month: "numeric",
-      day: "numeric",
-    });
+    return { activeGroups: groups, doneTasks };
+  }, [tasks, statusPriority, sortMode, todayKey]);
 
   return (
     <div className="space-y-6">
       {activeGroups.length > 0 && (
         <ul className="space-y-2">
-          {activeGroups.map(([date, items]) => (
-            <li key={date} className="glass-card p-4 w-full space-y-3">
-              <div className="text-sm font-semibold text-slate-700/90">
-                {date === "none" ? "No due date" : formatDate(date)}
-              </div>
+          {activeGroups.map(({ id, heading, items }) => (
+            <li key={id} className="glass-card p-4 w-full space-y-3">
+              <div className="text-sm font-semibold text-slate-700/90">{heading}</div>
               <ul className="space-y-2">
                 {items.map((t) => {
                   const milestone = milestones.find((m) => m.id === t.milestoneId);
@@ -80,10 +189,15 @@ export default function TaskChecklist({ tasks, team, milestones, onUpdate, onEdi
                     : t.dueDate
                     ? "Scheduled"
                     : "No Date";
+                  const isPriority = isPriorityTask(t);
+                  const priorityRing = isPriority
+                    ? "ring-2 ring-indigo-200/70 ring-offset-1 ring-offset-white"
+                    : "";
+                  const statusBadgeClass = STATUS_BADGE_TONES[t.status] || DEFAULT_STATUS_BADGE;
                   return (
                     <li key={t.id}>
                       <div
-                        className={`flex items-center gap-3 rounded-3xl border px-4 py-3 shadow-[0_18px_32px_-20px_rgba(15,23,42,0.45)] backdrop-blur transition-all ${containerTone}`}
+                        className={`flex items-center gap-3 rounded-3xl border px-4 py-3 shadow-[0_18px_32px_-20px_rgba(15,23,42,0.45)] backdrop-blur transition-all ${containerTone} ${priorityRing}`}
                       >
                         <input
                           type="checkbox"
@@ -109,11 +223,18 @@ export default function TaskChecklist({ tasks, team, milestones, onUpdate, onEdi
                             for {milestone ? milestone.title : "Unassigned"} • {assignee ? assignee.name : "Unassigned"}
                           </div>
                         </button>
-                        <span
-                          className={`shrink-0 self-start rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide shadow-sm backdrop-blur ${pillTone}`}
-                        >
-                          {pillLabel}
-                        </span>
+                        <div className="flex flex-col items-end gap-1 text-[11px] font-semibold uppercase tracking-wide">
+                          <span
+                            className={`shrink-0 rounded-full border px-2.5 py-1 shadow-sm backdrop-blur ${statusBadgeClass}`}
+                          >
+                            {STATUS_LABELS[t.status] || "Unknown"}
+                          </span>
+                          <span
+                            className={`shrink-0 rounded-full border px-2.5 py-1 shadow-sm backdrop-blur ${pillTone}`}
+                          >
+                            {pillLabel}
+                          </span>
+                        </div>
                       </div>
                     </li>
                   );


### PR DESCRIPTION
## Summary
- add a task list sort mode state and selector so course tasks can toggle between due date and status ordering
- wire the dashboard status rings to enable status sorting when they focus in-progress, to-do, or overdue tasks
- extend TaskChecklist with a status sort mode that groups tasks by status (or overdue) while preserving priority highlighting

## Testing
- npm test -- TaskChecklist *(fails: vitest binary unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e310aca4832b94b59059f7bc91a0