### PR TITLE
Default milestone task sorting to numeric order

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -607,6 +607,7 @@ function CoursePMApp({ boot, isTemplateLabel = false, onBack, onStateChange, peo
   const [view, setView] = useState("list");
   const [milestoneFilter, setMilestoneFilter] = useState("all");
   const [milestonesCollapsed, setMilestonesCollapsed] = useState(false);
+  const [milestoneTaskSort, setMilestoneTaskSort] = useState("numeric");
   const [teamCollapsed, setTeamCollapsed] = useState(true);
   const [tasksCollapsed, setTasksCollapsed] = useState(true);
   const [listPriority, setListPriority] = useState(null);
@@ -1976,6 +1977,8 @@ useEffect(() => {
                       milestone={m}
                       tasks={groupedTasks[m.id] || []}
                       tasksAll={tasksRaw}
+                      taskSort={milestoneTaskSort}
+                      onTaskSortChange={setMilestoneTaskSort}
                       team={team}
                       milestones={milestones}
                       onUpdate={updateTask}
@@ -2517,7 +2520,7 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
     const validTabs = new Set(['deadlines','courses','milestones','board','calendar']);
     return stored && validTabs.has(stored) ? stored : 'deadlines';
   });
-  const [milestoneSort, setMilestoneSort] = useState('status');
+  const milestoneSort = 'status';
   const { fireOnDone } = useCompletionConfetti();
 
   useEffect(() => {
@@ -3498,22 +3501,6 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
           {activeTab === 'milestones' && (
             <SectionCard
               title="My Milestones"
-              actions={
-                myCourses.length > 0 ? (
-                  <label className="text-sm text-slate-600 flex items-center gap-2">
-                    <span className="hidden sm:inline">Sort by</span>
-                    <select
-                      value={milestoneSort}
-                      onChange={(event) => setMilestoneSort(event.target.value)}
-                      className="rounded-lg border border-slate-300 bg-white px-2 py-1 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                      aria-label="Sort milestones"
-                    >
-                      <option value="status">Status</option>
-                      <option value="recent">Most Recent</option>
-                    </select>
-                  </label>
-                ) : null
-              }
             >
               {myCourses.length === 0 ? (
                 <div className="text-sm text-slate-600/90">No milestones</div>

--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -8,6 +8,8 @@ export default function MilestoneCard({
   tasksAll = [],
   team = [],
   milestones = [],
+  taskSort = 'numeric',
+  onTaskSortChange = () => {},
   onUpdate,
   onDelete,
   onDuplicate,
@@ -38,15 +40,88 @@ export default function MilestoneCard({
   const { pct, tasksSorted } = useMemo(() => {
     const completedCount = tasks.filter((t) => t.status === 'done' || t.status === 'skip').length;
     const pct = tasks.length ? Math.round((completedCount / tasks.length) * 100) : 0;
-    const tasksSorted = [...tasks].sort(
-      (a, b) =>
-        (statusOrder[a.status] ?? 99) - (statusOrder[b.status] ?? 99) ||
-        a.order - b.order,
-    );
+    const toTimestamp = (task) => {
+      const value = task?.dueDate;
+      if (!value) return null;
+      if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+      if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value.getTime();
+      if (typeof value === 'string') {
+        const parsed = Date.parse(value);
+        return Number.isNaN(parsed) ? null : parsed;
+      }
+      if (value && typeof value.toMillis === 'function') {
+        const millis = value.toMillis();
+        return Number.isFinite(millis) ? millis : null;
+      }
+      if (value && typeof value.toDate === 'function') {
+        const date = value.toDate();
+        if (date instanceof Date && !Number.isNaN(date.getTime())) return date.getTime();
+      }
+      if (value && typeof value.seconds === 'number') {
+        return value.seconds * 1000;
+      }
+      return null;
+    };
+    const compareTitle = (a, b) =>
+      (a.title || '').localeCompare(b.title || '', undefined, { sensitivity: 'base' });
+    const compareStatus = (a, b) =>
+      (statusOrder[a.status] ?? 99) - (statusOrder[b.status] ?? 99) ||
+      (a.order ?? 0) - (b.order ?? 0);
+    const extractNumeric = (task) => {
+      const match = (task?.title ?? '').match(/\d+/);
+      if (!match) return null;
+      const [raw] = match;
+      const normalized = raw.replace(/^0+/, '') || '0';
+      const value = Number.parseInt(normalized, 10);
+      if (!Number.isFinite(value)) return null;
+      return {
+        length: normalized.length,
+        value,
+        index: match.index ?? 0,
+      };
+    };
+    const compareNumeric = (a, b) => {
+      const aNum = extractNumeric(a);
+      const bNum = extractNumeric(b);
+      if (aNum && bNum) {
+        if (aNum.length !== bNum.length) return aNum.length - bNum.length;
+        if (aNum.value !== bNum.value) return aNum.value - bNum.value;
+        if (aNum.index !== bNum.index) return aNum.index - bNum.index;
+        return compareStatus(a, b) || compareTitle(a, b);
+      }
+      if (aNum) return -1;
+      if (bNum) return 1;
+      return compareStatus(a, b) || compareTitle(a, b);
+    };
+    const now = Date.now();
+    const compareDeadline = (a, b) => {
+      const aTs = toTimestamp(a);
+      const bTs = toTimestamp(b);
+      if (aTs === null && bTs === null) return compareTitle(a, b);
+      if (aTs === null) return 1;
+      if (bTs === null) return -1;
+      const aDiff = Math.abs(aTs - now);
+      const bDiff = Math.abs(bTs - now);
+      if (aDiff !== bDiff) return aDiff - bDiff;
+      if (aTs !== bTs) return aTs - bTs;
+      return compareTitle(a, b);
+    };
+    const sorter = taskSort === 'deadline'
+      ? compareDeadline
+      : taskSort === 'title'
+        ? (a, b) => compareTitle(a, b) || compareStatus(a, b)
+        : taskSort === 'status'
+          ? (a, b) => compareStatus(a, b) || compareTitle(a, b)
+          : compareNumeric;
+    const tasksSorted = [...tasks].sort(sorter);
     return { pct, tasksSorted };
-  }, [tasks]);
+  }, [tasks, taskSort]);
 
   const progressColor = `hsl(${210 + (pct / 100) * (140 - 210)}, 70%, 50%)`;
+
+  const handleTaskSortChange = (event) => {
+    onTaskSortChange(event.target.value);
+  };
 
   const triggerAddTask = () => {
     if (detailsRef.current) {
@@ -163,10 +238,28 @@ export default function MilestoneCard({
           )}
         </div>
       </summary>
-      <div className="p-4 flex flex-col gap-2">
-        {milestone.goal && (
-          <p className="text-sm text-black/60 mb-2">{milestone.goal}</p>
-        )}
+      <div className="p-4 flex flex-col gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          {milestone.goal && (
+            <p className="text-sm text-black/60 max-w-xl">{milestone.goal}</p>
+          )}
+          <label className="flex items-center gap-2 rounded-2xl border border-black/10 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm">
+            <span className="hidden sm:inline text-xs uppercase tracking-wide text-slate-500">
+              Sort by
+            </span>
+            <select
+              value={taskSort}
+              onChange={handleTaskSortChange}
+              className="bg-transparent text-sm font-medium text-slate-700 focus:outline-none"
+              aria-label="Sort tasks within milestones"
+            >
+              <option value="numeric">1–N</option>
+              <option value="status">Status</option>
+              <option value="title">A–Z</option>
+              <option value="deadline">Deadline</option>
+            </select>
+          </label>
+        </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
           {tasksSorted.map((t) => (
             <TaskCard

--- a/src/MilestoneCard.test.jsx
+++ b/src/MilestoneCard.test.jsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import MilestoneCard from './MilestoneCard.jsx';
+import { CoursePMApp } from './App.jsx';
 
 const milestone = { id: 'm1', title: 'Milestone 1', goal: '', start: '' };
 
@@ -25,8 +26,7 @@ describe('MilestoneCard', () => {
     ];
     render(<MilestoneCard milestone={milestone} tasks={tasks} />);
     const pct = 50;
-    const hue = 330 + (pct / 100) * (120 - 330);
-    const color = `hsl(${hue}, 70%, 50%)`;
+    const color = `hsl(${210 + (pct / 100) * (140 - 210)}, 70%, 50%)`;
     const bar = screen.getByTestId('progress-fill');
     expect(bar.getAttribute('style')).toContain(`background-color: ${color}`);
   });
@@ -43,6 +43,159 @@ describe('MilestoneCard', () => {
     expect(onAddTask).toHaveBeenCalledWith('m1');
     const details = container.querySelector('details');
     expect(details?.open).toBe(true);
+  });
+
+  it('sorts tasks numerically by default', () => {
+    const tasks = [
+      { id: 't1', title: 'Task 12', status: 'todo', order: 0 },
+      { id: 't2', title: 'Task 3', status: 'inprogress', order: 1 },
+      { id: 't3', title: 'Task 22', status: 'blocked', order: 2 },
+      { id: 't4', title: 'Task 1', status: 'todo', order: 3 },
+      { id: 't5', title: 'Task without number', status: 'todo', order: 4 },
+      { id: 't6', title: 'Task 105', status: 'todo', order: 5 },
+    ];
+
+    render(<MilestoneCard milestone={milestone} tasks={tasks} tasksAll={tasks} />);
+
+    const titles = screen
+      .getAllByTestId('task-card')
+      .map((card) => within(card).getByTitle('Click to edit').textContent);
+
+    expect(titles).toEqual([
+      'Task 1',
+      'Task 3',
+      'Task 12',
+      'Task 22',
+      'Task 105',
+      'Task without number',
+    ]);
+  });
+
+  it('sorts tasks alphabetically when requested', () => {
+    const tasks = [
+      { id: 't1', title: 'zeta', status: 'todo', order: 0 },
+      { id: 't2', title: 'Alpha', status: 'todo', order: 1 },
+      { id: 't3', title: 'beta', status: 'todo', order: 2 },
+    ];
+
+    render(
+      <MilestoneCard milestone={milestone} tasks={tasks} tasksAll={tasks} taskSort="title" />,
+    );
+
+    const titles = screen
+      .getAllByTestId('task-card')
+      .map((card) => within(card).getByTitle('Click to edit').textContent);
+
+    expect(titles).toEqual(['Alpha', 'beta', 'zeta']);
+  });
+
+  it('sorts tasks by status when requested', () => {
+    const tasks = [
+      { id: 't1', title: 'Done task', status: 'done', order: 0 },
+      { id: 't2', title: 'Todo task', status: 'todo', order: 2 },
+      { id: 't3', title: 'Blocked task', status: 'blocked', order: 1 },
+      { id: 't4', title: 'In progress task', status: 'inprogress', order: 3 },
+      { id: 't5', title: 'Skipped task', status: 'skip', order: 4 },
+    ];
+
+    render(
+      <MilestoneCard milestone={milestone} tasks={tasks} tasksAll={tasks} taskSort="status" />,
+    );
+
+    const titles = screen
+      .getAllByTestId('task-card')
+      .map((card) => within(card).getByTitle('Click to edit').textContent);
+
+    expect(titles).toEqual([
+      'Todo task',
+      'In progress task',
+      'Blocked task',
+      'Done task',
+      'Skipped task',
+    ]);
+  });
+
+  it('sorts tasks by deadline recency when requested', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2024-05-10T00:00:00Z'));
+
+      const tasks = [
+        { id: 't1', title: 'No due date', status: 'todo', order: 0, dueDate: '' },
+        { id: 't2', title: 'Due soon', status: 'todo', order: 1, dueDate: '2024-05-11' },
+        { id: 't3', title: 'Due today', status: 'todo', order: 2, dueDate: '2024-05-10' },
+        { id: 't4', title: 'Due earlier', status: 'todo', order: 3, dueDate: '2024-05-08' },
+      ];
+
+      render(
+        <MilestoneCard milestone={milestone} tasks={tasks} tasksAll={tasks} taskSort="deadline" />,
+      );
+
+      const titles = screen
+        .getAllByTestId('task-card')
+        .map((card) => within(card).getByTitle('Click to edit').textContent);
+
+      expect(titles).toEqual(['Due today', 'Due earlier', 'Due soon', 'No due date']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('CoursePMApp milestone task sorting', () => {
+  it('updates milestone task ordering when selecting different sort modes', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2024-05-10T00:00:00Z'));
+
+      const boot = {
+        course: { id: 'course-1', name: 'Course 1' },
+        team: [],
+        milestones: [
+          { id: 'm1', title: 'Alpha Milestone', goal: '' },
+        ],
+        tasks: [
+          { id: 't1', title: 'Task 11', status: 'todo', order: 2, milestoneId: 'm1', dueDate: '2024-05-11' },
+          { id: 't2', title: 'Task 2', status: 'inprogress', order: 1, milestoneId: 'm1', dueDate: '2024-05-09' },
+          { id: 't3', title: 'Task Beta', status: 'blocked', order: 0, milestoneId: 'm1', dueDate: '2024-05-15' },
+        ],
+        linkLibrary: [],
+        schedule: { workweek: [1, 2, 3, 4, 5], holidays: [] },
+      };
+
+      render(
+        <CoursePMApp
+          boot={boot}
+          isTemplateLabel={false}
+          onBack={() => {}}
+          onStateChange={() => {}}
+          people={[]}
+          milestoneTemplates={[]}
+          onChangeMilestoneTemplates={() => {}}
+          onOpenUser={() => {}}
+        />,
+      );
+
+      const readTaskTitles = () =>
+        screen
+          .getAllByTestId('task-card')
+          .map((card) => within(card).getByTitle('Click to edit').textContent);
+
+      expect(readTaskTitles()).toEqual(['Task 2', 'Task 11', 'Task Beta']);
+
+      const select = screen.getByLabelText('Sort tasks within milestones');
+
+      fireEvent.change(select, { target: { value: 'title' } });
+      expect(readTaskTitles()).toEqual(['Task 11', 'Task 2', 'Task Beta']);
+
+      fireEvent.change(select, { target: { value: 'status' } });
+      expect(readTaskTitles()).toEqual(['Task 11', 'Task 2', 'Task Beta']);
+
+      fireEvent.change(select, { target: { value: 'deadline' } });
+      expect(readTaskTitles()).toEqual(['Task 2', 'Task 11', 'Task Beta']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- remove the redundant milestone list sorting toolbar now that sorting is handled within each milestone card
- make numeric (1–N) ordering the default milestone task sort and extend MilestoneCard to rank titles with embedded numbers ahead of other modes
- adjust MilestoneCard tests and the CoursePMApp integration test to cover the numeric default alongside status, alphabetical, and deadline modes

## Testing
- `npm test` *(fails: vitest binary is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de4ffb2614832bb7b9c73202bc0a44