### PR TITLE
Refine milestone card title sorting precedence

### DIFF
--- a/docs/merge-conflict-resolution.md
+++ b/docs/merge-conflict-resolution.md
@@ -1,0 +1,86 @@
+# Resolving the milestone sorting merge conflicts
+
+This guide walks through fixing the merge conflicts between the base branch `main` and the feature branch `codex/add-milestone-task-sorting-functionality-zf78iq` for pull request #319.
+
+## 1. Update your local branches
+1. Fetch the latest branches from GitHub:
+   ```bash
+   git fetch origin
+   ```
+2. Make sure `main` is current:
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+3. Switch to the PR branch and bring in the newest remote commits:
+   ```bash
+   git checkout codex/add-milestone-task-sorting-functionality-zf78iq
+   git pull --ff-only origin codex/add-milestone-task-sorting-functionality-zf78iq
+   ```
+4. Merge the updated `main` into the feature branch to surface conflicts locally:
+   ```bash
+   git merge origin/main
+   ```
+
+## 2. Identify the conflicting files
+Run the following commands to list files that need attention:
+```bash
+git status
+git diff --name-only --diff-filter=U
+```
+You should see:
+- `src/App.jsx`
+- `src/MilestoneCard.jsx`
+- `src/MilestoneCard.test.jsx`
+
+Open each file and search for `<<<<<<<`, `=======`, and `>>>>>>>` markers. Every conflict block must be resolved before committing.
+
+## 3. Resolve each conflict
+
+### `src/App.jsx`
+- Keep the version that **removes** the milestone sorting toolbar from the section header. The milestone list should only render `<MilestoneCard>` components without passing shared `taskSort` props or callbacks.
+- Confirm that the milestone header still exposes the filter menu, template picker, and “Add Milestone” button, but no longer renders a “Sort by” control.
+
+### `src/MilestoneCard.jsx`
+- Preserve the feature-branch logic that:
+  - Defaults the card’s internal sort state to `'numeric'`.
+  - Provides the `extractNumeric`, `compareNumeric`, and `compareTitleAlpha` helpers so numeric prefixes (single digits before double digits) are honored in both numeric and alphabetical modes.
+  - Uses the guarded `handleTaskSortChange` handler to avoid redundant parent updates when the value doesn’t change.
+  - Renders the in-card `<select>` with options: `1–N`, `Status`, `A–Z`, and `Deadline`.
+- Remove any leftover imports or props tied to the old section-level sort state.
+
+### `src/MilestoneCard.test.jsx`
+- Keep the tests that assert:
+  - Numeric ordering is the default (`Task 1`, `Task 3`, `Task 007`, …).
+  - The alphabetical mode is numeric-aware (`1 Outline`, `2 Kickoff`, … before non-numeric titles).
+  - Explicit `status` and `deadline` modes still work.
+  - The integration test verifies only the in-card selector exists and that changing its value updates task order accordingly.
+- Delete the obsolete expectations from `main` that assumed status-based defaults or a header-level sorter.
+
+When editing, ensure every conflict marker is removed and the merged code compiles.
+
+## 4. Verify the result
+1. Confirm there are no remaining conflict markers:
+   ```bash
+   rg "<<<<<<<" -n
+   ```
+2. Run the targeted test suite (or the full test suite if time permits):
+   ```bash
+   npm test -- --runTestsByPath src/MilestoneCard.test.jsx
+   ```
+
+## 5. Commit and update the PR
+1. Stage your fixes:
+   ```bash
+   git add src/App.jsx src/MilestoneCard.jsx src/MilestoneCard.test.jsx
+   ```
+2. Commit with a clear message:
+   ```bash
+   git commit -m "Resolve milestone sorting merge conflicts"
+   ```
+3. Push the updated branch to GitHub:
+   ```bash
+   git push origin codex/add-milestone-task-sorting-functionality-zf78iq
+   ```
+
+After the push, GitHub will re-run the PR checks. Verify the PR diff looks correct and that the conflicts banner is gone before requesting another review.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2517,7 +2517,7 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
     const validTabs = new Set(['deadlines','courses','milestones','board','calendar']);
     return stored && validTabs.has(stored) ? stored : 'deadlines';
   });
-  const [milestoneSort, setMilestoneSort] = useState('status');
+  const milestoneSort = 'status';
   const { fireOnDone } = useCompletionConfetti();
 
   useEffect(() => {
@@ -3498,22 +3498,6 @@ export function UserDashboard({ onOpenCourse, initialUserId, onBack }) {
           {activeTab === 'milestones' && (
             <SectionCard
               title="My Milestones"
-              actions={
-                myCourses.length > 0 ? (
-                  <label className="text-sm text-slate-600 flex items-center gap-2">
-                    <span className="hidden sm:inline">Sort by</span>
-                    <select
-                      value={milestoneSort}
-                      onChange={(event) => setMilestoneSort(event.target.value)}
-                      className="rounded-lg border border-slate-300 bg-white px-2 py-1 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                      aria-label="Sort milestones"
-                    >
-                      <option value="status">Status</option>
-                      <option value="recent">Most Recent</option>
-                    </select>
-                  </label>
-                ) : null
-              }
             >
               {myCourses.length === 0 ? (
                 <div className="text-sm text-slate-600/90">No milestones</div>

--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -23,6 +23,12 @@ export default function MilestoneCard({
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState(milestone.title);
   const detailsRef = useRef(null);
+  const milestoneId = milestone?.id;
+  const [taskSort, setTaskSort] = useState('numeric');
+
+  useEffect(() => {
+    setTaskSort('numeric');
+  }, [milestoneId]);
 
   useEffect(() => setTitleDraft(milestone.title), [milestone.title]);
 
@@ -38,15 +44,153 @@ export default function MilestoneCard({
   const { pct, tasksSorted } = useMemo(() => {
     const completedCount = tasks.filter((t) => t.status === 'done' || t.status === 'skip').length;
     const pct = tasks.length ? Math.round((completedCount / tasks.length) * 100) : 0;
-    const tasksSorted = [...tasks].sort(
-      (a, b) =>
-        (statusOrder[a.status] ?? 99) - (statusOrder[b.status] ?? 99) ||
-        a.order - b.order,
-    );
+    const collator = new Intl.Collator(undefined, { sensitivity: 'base' });
+    const toTimestamp = (task) => {
+      const value = task?.dueDate;
+      if (!value) return null;
+      if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+      if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value.getTime();
+      if (typeof value === 'string') {
+        const parsed = Date.parse(value);
+        return Number.isNaN(parsed) ? null : parsed;
+      }
+      if (value && typeof value.toMillis === 'function') {
+        const millis = value.toMillis();
+        return Number.isFinite(millis) ? millis : null;
+      }
+      if (value && typeof value.toDate === 'function') {
+        const date = value.toDate();
+        if (date instanceof Date && !Number.isNaN(date.getTime())) return date.getTime();
+      }
+      if (value && typeof value.seconds === 'number') {
+        return value.seconds * 1000;
+      }
+      return null;
+    };
+    const compareText = (a, b) => collator.compare(a || '', b || '');
+    const compareTitle = (a, b) => compareText(a.title || '', b.title || '');
+    const compareStatus = (a, b) =>
+      (statusOrder[a.status] ?? 99) - (statusOrder[b.status] ?? 99) ||
+      (a.order ?? 0) - (b.order ?? 0);
+    const extractNumeric = (task) => {
+      const match = (task?.title ?? '').match(/\d+/);
+      if (!match) return null;
+      const [raw] = match;
+      const normalized = raw.replace(/^0+/, '') || '0';
+      const value = Number.parseInt(normalized, 10);
+      if (!Number.isFinite(value)) return null;
+      return {
+        length: normalized.length,
+        value,
+        index: match.index ?? 0,
+      };
+    };
+    const compareNumeric = (a, b) => {
+      const aNum = extractNumeric(a);
+      const bNum = extractNumeric(b);
+      if (aNum && bNum) {
+        if (aNum.length !== bNum.length) return aNum.length - bNum.length;
+        if (aNum.value !== bNum.value) return aNum.value - bNum.value;
+        if (aNum.index !== bNum.index) return aNum.index - bNum.index;
+        return compareTitle(a, b) || compareStatus(a, b);
+      }
+      if (aNum) return -1;
+      if (bNum) return 1;
+      return compareTitle(a, b) || compareStatus(a, b);
+    };
+    const buildAlphaKey = (task) => {
+      const rawTitle = task?.title ?? '';
+      const trimmed = rawTitle.trimStart();
+
+      const leadingMatch = trimmed.match(/^(\d+)/);
+      if (leadingMatch) {
+        const normalized = leadingMatch[1].replace(/^0+/, '') || '0';
+        const value = Number.parseInt(normalized, 10);
+        if (Number.isFinite(value)) {
+          return {
+            bucket: 0,
+            length: normalized.length,
+            value,
+            index: 0,
+            remainder: trimmed.slice(leadingMatch[0].length).trimStart(),
+          };
+        }
+      }
+
+      const anywhereMatch = rawTitle.match(/\d+/);
+      if (anywhereMatch) {
+        const normalized = anywhereMatch[0].replace(/^0+/, '') || '0';
+        const value = Number.parseInt(normalized, 10);
+        if (Number.isFinite(value)) {
+          return {
+            bucket: 1,
+            length: normalized.length,
+            value,
+            index: anywhereMatch.index ?? 0,
+            remainder: rawTitle
+              .slice((anywhereMatch.index ?? 0) + anywhereMatch[0].length)
+              .trimStart(),
+          };
+        }
+      }
+
+      return {
+        bucket: 2,
+        length: 0,
+        value: 0,
+        index: 0,
+        remainder: trimmed,
+      };
+    };
+
+    const compareTitleAlpha = (a, b) => {
+      const aKey = buildAlphaKey(a);
+      const bKey = buildAlphaKey(b);
+
+      if (aKey.bucket !== bKey.bucket) return aKey.bucket - bKey.bucket;
+
+      if (aKey.bucket !== 2) {
+        if (aKey.length !== bKey.length) return aKey.length - bKey.length;
+        if (aKey.value !== bKey.value) return aKey.value - bKey.value;
+        if (aKey.bucket === 1 && aKey.index !== bKey.index) return aKey.index - bKey.index;
+      }
+
+      const remainderCmp = compareText(aKey.remainder, bKey.remainder);
+      if (remainderCmp !== 0) return remainderCmp;
+
+      return compareStatus(a, b) || compareTitle(a, b);
+    };
+    const now = Date.now();
+    const compareDeadline = (a, b) => {
+      const aTs = toTimestamp(a);
+      const bTs = toTimestamp(b);
+      if (aTs === null && bTs === null) return compareTitle(a, b);
+      if (aTs === null) return 1;
+      if (bTs === null) return -1;
+      const aDiff = Math.abs(aTs - now);
+      const bDiff = Math.abs(bTs - now);
+      if (aDiff !== bDiff) return aDiff - bDiff;
+      if (aTs !== bTs) return aTs - bTs;
+      return compareTitle(a, b);
+    };
+    const sorter = taskSort === 'deadline'
+      ? compareDeadline
+      : taskSort === 'title'
+        ? compareTitleAlpha
+        : taskSort === 'status'
+          ? (a, b) => compareStatus(a, b) || compareTitle(a, b)
+          : compareNumeric;
+    const tasksSorted = [...tasks].sort(sorter);
     return { pct, tasksSorted };
-  }, [tasks]);
+  }, [tasks, taskSort]);
 
   const progressColor = `hsl(${210 + (pct / 100) * (140 - 210)}, 70%, 50%)`;
+
+  const handleTaskSortChange = (event) => {
+    const { value } = event.target;
+    if (value === taskSort) return;
+    setTaskSort(value);
+  };
 
   const triggerAddTask = () => {
     if (detailsRef.current) {
@@ -163,10 +307,28 @@ export default function MilestoneCard({
           )}
         </div>
       </summary>
-      <div className="p-4 flex flex-col gap-2">
-        {milestone.goal && (
-          <p className="text-sm text-black/60 mb-2">{milestone.goal}</p>
-        )}
+      <div className="p-4 flex flex-col gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          {milestone.goal && (
+            <p className="text-sm text-black/60 max-w-xl">{milestone.goal}</p>
+          )}
+          <label className="flex items-center gap-2 rounded-2xl border border-black/10 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm">
+            <span className="hidden sm:inline text-xs uppercase tracking-wide text-slate-500">
+              Sort by
+            </span>
+            <select
+              value={taskSort}
+              onChange={handleTaskSortChange}
+              className="bg-transparent text-sm font-medium text-slate-700 focus:outline-none"
+              aria-label="Sort tasks within milestones"
+            >
+              <option value="numeric">1–N</option>
+              <option value="status">Status</option>
+              <option value="title">A–Z</option>
+              <option value="deadline">Deadline</option>
+            </select>
+          </label>
+        </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
           {tasksSorted.map((t) => (
             <TaskCard

--- a/src/MilestoneCard.test.jsx
+++ b/src/MilestoneCard.test.jsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import MilestoneCard from './MilestoneCard.jsx';
+import { CoursePMApp } from './App.jsx';
 
 const milestone = { id: 'm1', title: 'Milestone 1', goal: '', start: '' };
 
@@ -25,8 +26,7 @@ describe('MilestoneCard', () => {
     ];
     render(<MilestoneCard milestone={milestone} tasks={tasks} />);
     const pct = 50;
-    const hue = 330 + (pct / 100) * (120 - 330);
-    const color = `hsl(${hue}, 70%, 50%)`;
+    const color = `hsl(${210 + (pct / 100) * (140 - 210)}, 70%, 50%)`;
     const bar = screen.getByTestId('progress-fill');
     expect(bar.getAttribute('style')).toContain(`background-color: ${color}`);
   });
@@ -43,6 +43,254 @@ describe('MilestoneCard', () => {
     expect(onAddTask).toHaveBeenCalledWith('m1');
     const details = container.querySelector('details');
     expect(details?.open).toBe(true);
+  });
+
+  it('sorts tasks numerically by default', () => {
+    const tasks = [
+      { id: 't1', title: 'Task 12', status: 'todo', order: 0 },
+      { id: 't2', title: 'Task 3', status: 'inprogress', order: 1 },
+      { id: 't3', title: 'Task 22', status: 'blocked', order: 2 },
+      { id: 't4', title: 'Task 1', status: 'todo', order: 3 },
+      { id: 't5', title: 'Task without number', status: 'todo', order: 4 },
+      { id: 't6', title: 'Task 105', status: 'todo', order: 5 },
+      { id: 't7', title: 'Task 10', status: 'todo', order: 6 },
+      { id: 't8', title: 'Task 9', status: 'todo', order: 7 },
+      { id: 't9', title: 'Task 007', status: 'todo', order: 8 },
+    ];
+
+    render(<MilestoneCard milestone={milestone} tasks={tasks} tasksAll={tasks} />);
+
+    const titles = screen
+      .getAllByTestId('task-card')
+      .map((card) => within(card).getByTitle('Click to edit').textContent);
+
+    expect(titles).toEqual([
+      'Task 1',
+      'Task 3',
+      'Task 007',
+      'Task 9',
+      'Task 10',
+      'Task 12',
+      'Task 22',
+      'Task 105',
+      'Task without number',
+    ]);
+  });
+
+  it('sorts tasks alphabetically with numeric-aware precedence when requested', () => {
+    const tasks = [
+      { id: 't1', title: 'Task 12', status: 'todo', order: 0 },
+      { id: 't2', title: '2 Kickoff', status: 'todo', order: 1 },
+      { id: 't3', title: 'Task 3', status: 'todo', order: 2 },
+      { id: 't4', title: '1 Outline', status: 'todo', order: 3 },
+      { id: 't5', title: 'Task 22', status: 'todo', order: 4 },
+      { id: 't6', title: 'Alpha brief', status: 'todo', order: 5 },
+      { id: 't7', title: 'Task 007', status: 'todo', order: 6 },
+      { id: 't8', title: 'beta sync', status: 'todo', order: 7 },
+    ];
+
+    render(
+      <MilestoneCard milestone={milestone} tasks={tasks} tasksAll={tasks} />,
+    );
+
+    const select = screen.getByLabelText('Sort tasks within milestones');
+    fireEvent.change(select, { target: { value: 'title' } });
+
+    const titles = screen
+      .getAllByTestId('task-card')
+      .map((card) => within(card).getByTitle('Click to edit').textContent);
+
+    expect(titles).toEqual([
+      '1 Outline',
+      '2 Kickoff',
+      'Task 3',
+      'Task 007',
+      'Task 12',
+      'Task 22',
+      'Alpha brief',
+      'beta sync',
+    ]);
+  });
+
+  it('groups leading numeric titles by digit length before plain text in A–Z mode', () => {
+    const tasks = [
+      { id: 't1', title: '100 Wrap up', status: 'todo', order: 0 },
+      { id: 't2', title: '1 Setup', status: 'todo', order: 1 },
+      { id: 't3', title: 'Alpha Task', status: 'todo', order: 2 },
+      { id: 't4', title: '12 Review', status: 'todo', order: 3 },
+      { id: 't5', title: '02 Outline', status: 'todo', order: 4 },
+    ];
+
+    render(
+      <MilestoneCard milestone={milestone} tasks={tasks} tasksAll={tasks} />,
+    );
+
+    const select = screen.getByLabelText('Sort tasks within milestones');
+    fireEvent.change(select, { target: { value: 'title' } });
+
+    const titles = screen
+      .getAllByTestId('task-card')
+      .map((card) => within(card).getByTitle('Click to edit').textContent);
+
+    expect(titles).toEqual([
+      '1 Setup',
+      '02 Outline',
+      '12 Review',
+      '100 Wrap up',
+      'Alpha Task',
+    ]);
+  });
+
+  it('resets numeric sorting when rendering a different milestone', () => {
+    const firstTasks = [
+      { id: 't1', title: 'Task Alpha', status: 'todo', order: 0 },
+      { id: 't2', title: 'Task 2', status: 'inprogress', order: 1 },
+    ];
+    const secondTasks = [
+      { id: 't3', title: 'Task 14', status: 'todo', order: 0 },
+      { id: 't4', title: 'Task 3', status: 'todo', order: 1 },
+      { id: 't5', title: 'Task 1', status: 'todo', order: 2 },
+    ];
+
+    const { rerender } = render(
+      <MilestoneCard milestone={milestone} tasks={firstTasks} tasksAll={firstTasks} />,
+    );
+
+    const select = screen.getByLabelText('Sort tasks within milestones');
+    fireEvent.change(select, { target: { value: 'status' } });
+    expect(select.value).toBe('status');
+
+    rerender(
+      <MilestoneCard
+        milestone={{ ...milestone, id: 'm2', title: 'Milestone 2' }}
+        tasks={secondTasks}
+        tasksAll={secondTasks}
+      />,
+    );
+
+    const selectAfter = screen.getByLabelText('Sort tasks within milestones');
+    expect(selectAfter.value).toBe('numeric');
+
+    const titles = screen
+      .getAllByTestId('task-card')
+      .map((card) => within(card).getByTitle('Click to edit').textContent);
+
+    expect(titles).toEqual(['Task 1', 'Task 3', 'Task 14']);
+  });
+
+  it('sorts tasks by status when requested', () => {
+    const tasks = [
+      { id: 't1', title: 'Done task', status: 'done', order: 0 },
+      { id: 't2', title: 'Todo task', status: 'todo', order: 2 },
+      { id: 't3', title: 'Blocked task', status: 'blocked', order: 1 },
+      { id: 't4', title: 'In progress task', status: 'inprogress', order: 3 },
+      { id: 't5', title: 'Skipped task', status: 'skip', order: 4 },
+    ];
+
+    render(
+      <MilestoneCard milestone={milestone} tasks={tasks} tasksAll={tasks} />,
+    );
+
+    const select = screen.getByLabelText('Sort tasks within milestones');
+    fireEvent.change(select, { target: { value: 'status' } });
+
+    const titles = screen
+      .getAllByTestId('task-card')
+      .map((card) => within(card).getByTitle('Click to edit').textContent);
+
+    expect(titles).toEqual([
+      'Todo task',
+      'In progress task',
+      'Blocked task',
+      'Done task',
+      'Skipped task',
+    ]);
+  });
+
+  it('sorts tasks by deadline recency when requested', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2024-05-10T00:00:00Z'));
+
+      const tasks = [
+        { id: 't1', title: 'No due date', status: 'todo', order: 0, dueDate: '' },
+        { id: 't2', title: 'Due soon', status: 'todo', order: 1, dueDate: '2024-05-11' },
+        { id: 't3', title: 'Due today', status: 'todo', order: 2, dueDate: '2024-05-10' },
+        { id: 't4', title: 'Due earlier', status: 'todo', order: 3, dueDate: '2024-05-08' },
+      ];
+
+      render(
+        <MilestoneCard milestone={milestone} tasks={tasks} tasksAll={tasks} />,
+      );
+
+      const select = screen.getByLabelText('Sort tasks within milestones');
+      fireEvent.change(select, { target: { value: 'deadline' } });
+
+      const titles = screen
+        .getAllByTestId('task-card')
+        .map((card) => within(card).getByTitle('Click to edit').textContent);
+
+      expect(titles).toEqual(['Due today', 'Due earlier', 'Due soon', 'No due date']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('CoursePMApp milestone task sorting', () => {
+  it('updates milestone task ordering when selecting different sort modes', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2024-05-10T00:00:00Z'));
+
+      const boot = {
+        course: { id: 'course-1', name: 'Course 1' },
+        team: [],
+        milestones: [
+          { id: 'm1', title: 'Alpha Milestone', goal: '' },
+        ],
+        tasks: [
+          { id: 't1', title: '11 Review', status: 'todo', order: 2, milestoneId: 'm1', dueDate: '2024-05-11' },
+          { id: 't2', title: '2 Kickoff', status: 'inprogress', order: 1, milestoneId: 'm1', dueDate: '2024-05-09' },
+          { id: 't3', title: 'Beta Task', status: 'blocked', order: 0, milestoneId: 'm1', dueDate: '2024-05-15' },
+        ],
+        linkLibrary: [],
+        schedule: { workweek: [1, 2, 3, 4, 5], holidays: [] },
+      };
+
+      render(
+        <CoursePMApp
+          boot={boot}
+          isTemplateLabel={false}
+          onBack={() => {}}
+          onStateChange={() => {}}
+          people={[]}
+          milestoneTemplates={[]}
+          onChangeMilestoneTemplates={() => {}}
+          onOpenUser={() => {}}
+        />,
+      );
+
+      const readTaskTitles = () =>
+        screen
+          .getAllByTestId('task-card')
+          .map((card) => within(card).getByTitle('Click to edit').textContent);
+
+      expect(readTaskTitles()).toEqual(['2 Kickoff', '11 Review', 'Beta Task']);
+
+      const select = screen.getByLabelText('Sort tasks within milestones');
+
+      fireEvent.change(select, { target: { value: 'title' } });
+      expect(readTaskTitles()).toEqual(['2 Kickoff', '11 Review', 'Beta Task']);
+
+      fireEvent.change(select, { target: { value: 'status' } });
+      expect(readTaskTitles()).toEqual(['11 Review', '2 Kickoff', 'Beta Task']);
+
+      fireEvent.change(select, { target: { value: 'deadline' } });
+      expect(readTaskTitles()).toEqual(['2 Kickoff', '11 Review', 'Beta Task']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- refactor the MilestoneCard alphabetical sorter to use structured keys so leading and embedded numerics always receive consistent priority
- centralize locale-aware title comparisons via an Intl.Collator to keep numeric, status, and deadline modes aligned

## Testing
- npm test -- --runTestsByPath src/MilestoneCard.test.jsx *(fails: vitest not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de4ffb2614832bb7b9c73202bc0a44