### PR TITLE
Remove duplicate Milestones sort control

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1960,21 +1960,6 @@ useEffect(() => {
                         </div>
                       )}
                     </div>
-                    <label className="flex items-center gap-2 rounded-2xl border border-white/60 bg-white/80 px-3 py-2 text-sm shadow-sm w-full sm:w-auto">
-                      <span className="text-xs font-medium uppercase tracking-wide text-slate-500">
-                        Sort by
-                      </span>
-                      <select
-                        value={milestoneTaskSort}
-                        onChange={(event) => setMilestoneTaskSort(event.target.value)}
-                        className="bg-transparent text-sm font-medium text-slate-700 focus:outline-none"
-                        aria-label="Sort tasks within milestones"
-                      >
-                        <option value="status">Status</option>
-                        <option value="title">A–Z</option>
-                        <option value="deadline">Deadline</option>
-                      </select>
-                    </label>
                     {milestoneTemplates.length > 0 && (
                       <div className="flex items-center gap-2 w-full sm:w-auto">
                         <select


### PR DESCRIPTION
## Summary
- remove the redundant Milestones "Sort by" dropdown from the section header since sorting is already available within each milestone card

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: vite not found because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df1584ecbc832b8dd8fb90377f8257