### PR TITLE
Add modal to manage milestone templates separately

### DIFF
--- a/src/milestoneTemplatesStore.js
+++ b/src/milestoneTemplatesStore.js
@@ -69,9 +69,24 @@ export const removeTemplate = (id) => {
   return templates;
 };
 
+export const updateTemplate = (id, updates = {}) => {
+  const templates = loadMilestoneTemplates();
+  const next = templates.map((tpl) =>
+    tpl.id === id ? { ...tpl, ...updates } : tpl
+  );
+  saveMilestoneTemplates(next);
+  saveMilestoneTemplatesRemote(next).catch(() => {});
+  return next;
+};
+
 export const createTemplateFromMilestone = (milestone, tasks = []) => {
   const templateTasks = tasks.map(({ id, order, milestoneId, ...rest }) => ({ ...rest }));
   const template = { id: uid(), title: milestone.title, goal: milestone.goal, tasks: templateTasks };
+  return addTemplate(template);
+};
+
+export const createEmptyTemplate = () => {
+  const template = { id: uid(), title: "New template", goal: "", tasks: [] };
   return addTemplate(template);
 };
 


### PR DESCRIPTION
## Summary
- replace the inline milestone template picker with a dedicated Template Library modal
- allow creating, renaming, editing notes, deleting, and adding templates to a course from the modal
- add store helpers for updating and creating blank milestone templates

## Testing
- npm run build *(fails: vite is not available in the execution environment before dependencies are installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e3471f6290832b9690f286cd03e59a