### PR TITLE
Clarify milestone save actions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -102,6 +102,49 @@ import {
   normalizeCourseHistoryEntryList,
 } from "./courseHistoryStore.js";
 
+const TEMPLATE_COLOR_SCHEMES = [
+  {
+    cardBg: "bg-indigo-50/80",
+    cardBorder: "border-indigo-200/80",
+    ribbon: "bg-indigo-400/70",
+    labelText: "text-indigo-700",
+    badgeBg: "bg-indigo-100/90",
+    badgeText: "text-indigo-700",
+    inputBorder: "border-indigo-200/70",
+    focusRing: "focus:border-indigo-400 focus:ring-indigo-300/70",
+  },
+  {
+    cardBg: "bg-emerald-50/80",
+    cardBorder: "border-emerald-200/80",
+    ribbon: "bg-emerald-400/70",
+    labelText: "text-emerald-700",
+    badgeBg: "bg-emerald-100/90",
+    badgeText: "text-emerald-700",
+    inputBorder: "border-emerald-200/70",
+    focusRing: "focus:border-emerald-400 focus:ring-emerald-300/70",
+  },
+  {
+    cardBg: "bg-sky-50/80",
+    cardBorder: "border-sky-200/80",
+    ribbon: "bg-sky-400/70",
+    labelText: "text-sky-700",
+    badgeBg: "bg-sky-100/90",
+    badgeText: "text-sky-700",
+    inputBorder: "border-sky-200/70",
+    focusRing: "focus:border-sky-400 focus:ring-sky-300/70",
+  },
+  {
+    cardBg: "bg-amber-50/80",
+    cardBorder: "border-amber-200/80",
+    ribbon: "bg-amber-400/70",
+    labelText: "text-amber-700",
+    badgeBg: "bg-amber-100/90",
+    badgeText: "text-amber-700",
+    inputBorder: "border-amber-200/70",
+    focusRing: "focus:border-amber-400 focus:ring-amber-300/70",
+  },
+];
+
 const STATUS_PRIORITY_LABELS = {
   inprogress: "In Progress",
   todo: "To Do",
@@ -2356,6 +2399,7 @@ useEffect(() => {
                       onDuplicateMilestone={duplicateMilestone}
                       onDeleteMilestone={deleteMilestone}
                       onUpdateMilestone={updateMilestone}
+                      onSaveMilestone={handleSave}
                       onSaveAsTemplate={saveMilestoneTemplate}
                       onAddTask={addTask}
                       onAddLink={(id, url) => patchTaskLinks(id, 'add', url)}
@@ -2610,17 +2654,35 @@ useEffect(() => {
                     </div>
                   ) : (
                     <div className="mt-6 space-y-4">
-                      {milestoneTemplates.map((tpl) => {
+                      {milestoneTemplates.map((tpl, index) => {
+                        const accent = TEMPLATE_COLOR_SCHEMES[index % TEMPLATE_COLOR_SCHEMES.length];
                         const draft = templateDrafts[tpl.id] || { title: tpl.title || "", goal: tpl.goal || "" };
                         const isDirty =
                           draft.title !== (tpl.title || "") ||
                           (draft.goal || "") !== (tpl.goal || "");
                         const isEditing = editingTemplateId === tpl.id;
                         return (
-                          <div key={tpl.id} className="rounded-3xl border border-slate-200/80 bg-slate-50/90 p-5 shadow-sm">
+                          <div
+                            key={tpl.id}
+                            className={`relative rounded-3xl border ${accent.cardBorder} ${accent.cardBg} p-5 shadow-sm transition-shadow`}
+                          >
+                            <span
+                              className={`pointer-events-none absolute inset-x-0 top-0 h-1.5 ${accent.ribbon}`}
+                              aria-hidden="true"
+                            />
                             <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
                               <div className="flex-1 space-y-3">
-                                <label className="block text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                <div className="flex items-center justify-between">
+                                  <span
+                                    className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${accent.badgeBg} ${accent.badgeText}`}
+                                  >
+                                    {`Milestone ${index + 1}`}
+                                  </span>
+                                  <span className="text-xs font-medium text-slate-500">
+                                    {isDirty ? "Unsaved changes" : "Saved"}
+                                  </span>
+                                </div>
+                                <label className={`block text-xs font-semibold uppercase tracking-wide ${accent.labelText}`}>
                                   Template name
                                 </label>
                                 <input
@@ -2634,17 +2696,17 @@ useEffect(() => {
                                       persistTemplateDraft(tpl.id);
                                     }
                                   }}
-                                  className="w-full rounded-2xl border border-slate-200/80 bg-white/90 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-300/70"
+                                  className={`w-full rounded-2xl border bg-white/95 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 ${accent.inputBorder} ${accent.focusRing}`}
                                   placeholder="Untitled template"
                                 />
-                                <label className="block text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                <label className={`block text-xs font-semibold uppercase tracking-wide ${accent.labelText}`}>
                                   Goal / notes
                                 </label>
                                 <textarea
                                   value={draft.goal}
                                   onChange={(event) => handleTemplateDraftChange(tpl.id, "goal", event.target.value)}
                                   onBlur={() => persistTemplateDraft(tpl.id)}
-                                  className="w-full rounded-2xl border border-slate-200/80 bg-white/90 px-3 py-2 text-sm shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-300/70"
+                                  className={`w-full rounded-2xl border bg-white/95 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 ${accent.inputBorder} ${accent.focusRing}`}
                                   rows={3}
                                   placeholder="What is this template for?"
                                 />

--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useEffect, useRef } from 'react';
 import TaskCard from './TaskCard.jsx';
-import { Copy, Save, Trash, ChevronDown, Plus } from 'lucide-react';
+import { Copy, Save, Trash, ChevronDown, Plus, BookmarkPlus } from 'lucide-react';
 
 export default function MilestoneCard({
   milestone,
@@ -18,6 +18,7 @@ export default function MilestoneCard({
   onAddLink,
   onRemoveLink,
   onUpdateMilestone,
+  onSaveMilestone,
   onSaveAsTemplate,
   onAddTask,
   reporter = null,
@@ -200,18 +201,32 @@ export default function MilestoneCard({
               <Copy className="icon" />
             </button>
           )}
+          {onSaveMilestone && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onSaveMilestone(milestone.id);
+              }}
+              className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-indigo-200 bg-indigo-50 text-indigo-600 hover:bg-indigo-100"
+              title="Save milestone to course"
+              aria-label="Save milestone to course"
+              type="button"
+            >
+              <Save className="icon" />
+            </button>
+          )}
           {onSaveAsTemplate && (
             <button
               onClick={(e) => {
                 e.stopPropagation();
                 onSaveAsTemplate(milestone.id);
               }}
-              className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-black/10 bg-green-50 text-green-600 hover:bg-green-100"
-              title="Save as Milestone Template"
-              aria-label="Save as Milestone Template"
+              className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-amber-200 bg-amber-50 text-amber-600 hover:bg-amber-100"
+              title="Save as milestone template"
+              aria-label="Save as milestone template"
               type="button"
             >
-              <Save className="icon" />
+              <BookmarkPlus className="icon" />
             </button>
           )}
           {onDeleteMilestone && (

--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -207,12 +207,13 @@ export default function MilestoneCard({
                 e.stopPropagation();
                 onSaveMilestone(milestone.id);
               }}
-              className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-indigo-200 bg-indigo-50 text-indigo-600 hover:bg-indigo-100"
+              className="inline-flex items-center gap-1.5 rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1.5 text-xs font-semibold text-indigo-700 transition hover:bg-indigo-100 sm:text-sm"
               title="Save milestone to course"
               aria-label="Save milestone to course"
               type="button"
             >
               <Save className="icon" />
+              <span>Save</span>
             </button>
           )}
           {onSaveAsTemplate && (
@@ -221,12 +222,13 @@ export default function MilestoneCard({
                 e.stopPropagation();
                 onSaveAsTemplate(milestone.id);
               }}
-              className="inline-flex items-center justify-center w-8 h-8 sm:w-9 sm:h-9 rounded-full border border-amber-200 bg-amber-50 text-amber-600 hover:bg-amber-100"
+              className="inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs font-semibold text-amber-700 transition hover:bg-amber-100 sm:text-sm"
               title="Save as milestone template"
               aria-label="Save as milestone template"
               type="button"
             >
               <BookmarkPlus className="icon" />
+              <span>Template</span>
             </button>
           )}
           {onDeleteMilestone && (

--- a/src/MilestoneCard.test.jsx
+++ b/src/MilestoneCard.test.jsx
@@ -50,6 +50,36 @@ describe('MilestoneCard', () => {
     expect(details?.open).toBe(true);
   });
 
+  it('saves a milestone into the course when requested', () => {
+    const onSaveMilestone = vi.fn();
+    render(
+      <MilestoneCard
+        milestone={milestone}
+        onSaveMilestone={onSaveMilestone}
+      />,
+    );
+
+    const saveButton = screen.getByLabelText('Save milestone to course');
+    fireEvent.click(saveButton);
+
+    expect(onSaveMilestone).toHaveBeenCalledWith('m1');
+  });
+
+  it('saves a milestone as a reusable template', () => {
+    const onSaveAsTemplate = vi.fn();
+    render(
+      <MilestoneCard
+        milestone={milestone}
+        onSaveAsTemplate={onSaveAsTemplate}
+      />,
+    );
+
+    const templateButton = screen.getByLabelText('Save as milestone template');
+    fireEvent.click(templateButton);
+
+    expect(onSaveAsTemplate).toHaveBeenCalledWith('m1');
+  });
+
   it('sorts tasks by numeric order by default', () => {
     const tasks = [
       { id: 't1', title: 'First task', status: 'todo', order: 1 },


### PR DESCRIPTION
## Summary
- add a dedicated course save control to each milestone card while keeping template actions separate
- swap the milestone template button to a distinct icon and color treatment to reduce confusion
- extend milestone card tests to cover the new save behaviors

## Testing
- npm test -- --runInBand *(fails: vitest is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e35efd31a4832b9f31a8018d2a217d