### PR TITLE
Ensure milestone tasks render in a single column

### DIFF
--- a/src/MilestoneCard.jsx
+++ b/src/MilestoneCard.jsx
@@ -268,7 +268,7 @@ export default function MilestoneCard({
             </select>
           </label>
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+        <div className="grid grid-cols-1 gap-2">
           {tasksSorted.map((t) => (
             <TaskCard
               key={t.id}


### PR DESCRIPTION
## Summary
- remove the responsive two-column grid from milestone task lists so they always render in a single column

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e393a0f118832b8c4bca75b300b29d