### PR TITLE
Fix DART logo asset resolution

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState, useRef, Fragment, useCallback } from "react";
+import dartLogoUrl from "./dartlogo.png";
 import { useIsMobile } from "./hooks/use-is-mobile.js";
 import { useCompletionConfetti } from "./hooks/use-completion-confetti.js";
 import { AnimatePresence, motion, useAnimation } from "framer-motion";
@@ -1994,7 +1995,7 @@ useEffect(() => {
             </button>
           )}
           <img
-            src="/dartlogo.png"
+            src={dartLogoUrl}
             alt="DART logo"
             className="h-9 w-auto max-w-[150px] object-contain drop-shadow-[0_8px_20px_rgba(15,23,42,0.18)]"
           />
@@ -5446,7 +5447,7 @@ export function CoursesHub({
         <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between gap-3">
           <div className="flex items-center gap-3 min-w-0">
             <img
-              src="/dartlogo.png"
+              src={dartLogoUrl}
               alt="DART logo"
               className="h-9 w-auto max-w-[150px] object-contain drop-shadow-[0_8px_20px_rgba(15,23,42,0.18)]"
             />


### PR DESCRIPTION
## Summary
- import the DART logo asset in App.jsx so Vite resolves the correct public URL for both headers

## Testing
- npm install *(fails: 403 Forbidden fetching @tailwindcss/forms)*

------
https://chatgpt.com/codex/tasks/task_e_68e3acf9899c832b82b6ad410e16dd78