### PR TITLE
Use official logo and reorganize mobile header layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import TaskChecklist from "./components/TaskChecklist.jsx";
 import TaskCard from "./TaskCard.jsx";
 import LinkReminderModal from "./components/LinkReminderModal.jsx";
 import BlockDialog from "./components/BlockDialog.jsx";
+import dartLogoImage from "./dartlogo.png";
 import { applyLinkPatch, syncLinkLibraryWithMilestone } from "./linkUtils.js";
 import { SoundContext } from "./sound-context.js";
 import pkg from "../package.json";
@@ -102,25 +103,14 @@ import {
   normalizeCourseHistoryEntryList,
 } from "./courseHistoryStore.js";
 
-const GradientLogo = ({ className = "" }) => {
-  const combinedClassName = [
-    "grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[linear-gradient(135deg,#16a34a,#22c55e)] shadow-[0_8px_20px_rgba(15,23,42,0.18)]",
-    className,
-  ]
-    .filter(Boolean)
-    .join(" ");
-
-  return (
-    <div role="img" aria-label="DART logo" className={combinedClassName}>
-      <svg viewBox="0 0 24 24" className="h-5 w-5 text-white" aria-hidden="true">
-        <path
-          fill="currentColor"
-          d="M5.5 4h6.75c3.91 0 6.75 2.71 6.75 6.5s-2.84 6.5-6.75 6.5H9.5V20H5.5V4zm4 4v5h2.75c1.69 0 2.75-1.07 2.75-2.5S13.94 8 12.25 8H9.5z"
-        />
-      </svg>
-    </div>
-  );
-};
+const DartLogo = ({ className = "" }) => (
+  <img
+    src={dartLogoImage}
+    alt="DART logo"
+    className={["h-10 w-auto shrink-0 drop-shadow-sm", className].filter(Boolean).join(" ")}
+    loading="lazy"
+  />
+);
 
 const TEMPLATE_COLOR_SCHEMES = [
   {
@@ -2003,21 +1993,28 @@ useEffect(() => {
     <div className={APP_SHELL_CLASS}>
       {/* Header */}
       <header className="sticky top-0 z-30 border-b border-white/50 bg-white/70 supports-[backdrop-filter]:bg-white/30 backdrop-blur-2xl backdrop-saturate-150 shadow-[0_16px_48px_rgba(15,23,42,0.12)]">
-        <div className="max-w-7xl mx-auto px-4 py-3 flex flex-wrap items-center gap-3 sm:flex-nowrap">
-          {onBack && (
-            <button
-              onClick={onBack}
-              className="glass-button-primary inline-flex items-center gap-2"
-            >
-              <CoursesIcon className="shrink-0" />
-              <span>Back to Courses</span>
-            </button>
-          )}
-          <GradientLogo />
-          {/* DART banner title */}
-          <div className="hidden sm:block text-[15px] font-semibold text-slate-700/90 tracking-tight truncate">DART: Design and Development Accountability and Responsibility Tracker</div>
-          <div className="flex-1" />
-          <div className="w-full flex justify-end sm:w-auto">
+        <div className="max-w-7xl mx-auto px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-6">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4 sm:min-w-0">
+            <div className="flex items-center gap-3 sm:min-w-0">
+              <DartLogo />
+              <div className="hidden sm:block text-[15px] font-semibold text-slate-700/90 tracking-tight truncate">
+                DART: Design and Development Accountability and Responsibility Tracker
+              </div>
+              <div className="text-sm font-semibold text-slate-700/90 tracking-tight sm:hidden">
+                DART Accountability Tracker
+              </div>
+            </div>
+            {onBack && (
+              <button
+                onClick={onBack}
+                className="glass-button-primary inline-flex w-full items-center justify-center gap-2 sm:w-auto"
+              >
+                <CoursesIcon className="shrink-0" />
+                <span>Back to Courses</span>
+              </button>
+            )}
+          </div>
+          <div className="flex items-center justify-end gap-3 sm:ml-auto">
             <div className="hidden sm:flex flex-wrap items-center gap-3">
               <ActionButtons />
             </div>
@@ -5459,40 +5456,49 @@ export function CoursesHub({
   return (
     <div className={APP_SHELL_CLASS}>
       <header className="sticky top-0 z-20 border-b border-white/50 bg-white/70 supports-[backdrop-filter]:bg-white/30 backdrop-blur-2xl backdrop-saturate-150 shadow-[0_16px_48px_rgba(15,23,42,0.12)]">
-        <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between gap-3">
+        <div className="max-w-7xl mx-auto px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
           <div className="flex items-center gap-3 min-w-0">
-            <GradientLogo />
+            <DartLogo className="h-9 sm:h-10" />
             <div className="min-w-0">
-              <div className="text-sm sm:text-[15px] font-semibold text-slate-700/90 truncate">DART: Design and Development Accountability and Responsibility Tracker</div>
+              <div className="hidden sm:block text-sm sm:text-[15px] font-semibold text-slate-700/90 truncate">
+                DART: Design and Development Accountability and Responsibility Tracker
+              </div>
+              <div className="text-sm font-semibold text-slate-700/90 sm:hidden">
+                DART Accountability Tracker
+              </div>
               <div className="text-sm text-slate-700 truncate flex items-center gap-2">
                 <CoursesIcon className="shrink-0" />
                 <span className="truncate">Courses Hub</span>
               </div>
             </div>
           </div>
-          <div className="flex items-center gap-3">
-            <button onClick={onEditTemplate} className="glass-button">Edit Template</button>
-            <button
-              onClick={() => setHistoryModalOpen(true)}
-              className="glass-button flex items-center gap-2"
-            >
-              <History className="icon" />
-              <span className="hidden sm:inline">Version history</span>
-              <span className="sm:hidden">History</span>
-            </button>
-            <button
-              onClick={undo}
-              disabled={!history.length}
-              className="glass-button disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Undo
-            </button>
-            <button
-              onClick={handleAddCourse}
-              className="glass-button-primary"
-            >
-              Add Course
-            </button>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+              <button onClick={onEditTemplate} className="glass-button w-full sm:w-auto">Edit Template</button>
+              <button
+                onClick={() => setHistoryModalOpen(true)}
+                className="glass-button flex items-center justify-center gap-2"
+              >
+                <History className="icon" />
+                <span className="hidden sm:inline">Version history</span>
+                <span className="sm:hidden">History</span>
+              </button>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+              <button
+                onClick={undo}
+                disabled={!history.length}
+                className="glass-button disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Undo
+              </button>
+              <button
+                onClick={handleAddCourse}
+                className="glass-button-primary"
+              >
+                Add Course
+              </button>
+            </div>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- replace the gradient placeholder with the official DART logo asset and reusable component
- reorganize the course header layout so actions stack on mobile instead of overlapping the logo
- update the courses hub header to share the mobile-friendly layout and button grouping

## Testing
- npm test -- --runInBand *(fails: vitest missing because dependencies cannot be installed in the container)*
- npm install *(fails: npm registry request for @tailwindcss/forms is blocked with 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e44d40d188832bb4868ecc65cf8eca